### PR TITLE
uart related fixes

### DIFF
--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -128,8 +128,13 @@ class manager:
             self.monitor[0].start_log()
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
-            out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
-            if not out:
+            try:
+                out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
+                if not out:
+                    raise ne.LinuxNotReached
+            except Exception as e:
+                # raise LinuxNotReached for other exceptions
+                log.info(str(e))
                 raise ne.LinuxNotReached
 
             # Get IP over UART
@@ -368,8 +373,13 @@ class manager:
             self.monitor[0].start_log()
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
-            out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
-            if not out:
+            try:
+                out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
+                if not out:
+                    raise ne.LinuxNotReached
+            except Exception as e:
+                # raise LinuxNotReached for other exceptions
+                log.info(str(e))
                 raise ne.LinuxNotReached
 
             # Get IP over UART

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -83,7 +83,7 @@ class uart(utils):
             self.com.close()
 
     def is_open(self):
-        self.com.is_open()
+        return self.com.is_open
 
     def reinitialize_uart(self):
         log.info("Reinitializing UART")

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -82,6 +82,9 @@ class uart(utils):
         if self.com:
             self.com.close()
 
+    def is_open(self):
+        self.com.is_open()
+
     def reinitialize_uart(self):
         log.info("Reinitializing UART")
         if self.com:

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -307,28 +307,32 @@ class uart(utils):
         return logged_in
 
     def _check_for_login(self):
-        for _ in range(2):  # Check at least twice
-            cmd = ""
-            self._write_data(cmd)
-            data = self._read_for_time(period=1)
-            needs_login = False
-            for d in data:
-                if isinstance(d, list):
-                    for c in d:
-                        c = c.replace("\r", "")
-                        log.info(c)
-                        if "login:" in c:
-                            needs_login = True
         logged_in=False
-        if needs_login:
-            # Do login
-            if self._attemp_login("root","analog"):
-                return True
+        try:
+            for _ in range(2):  # Check at least twice
+                cmd = ""
+                self._write_data(cmd)
+                data = self._read_for_time(period=1)
+                needs_login = False
+                for d in data:
+                    if isinstance(d, list):
+                        for c in d:
+                            c = c.replace("\r", "")
+                            log.info(c)
+                            if "login:" in c:
+                                needs_login = True
+            
+            if needs_login:
+                # Do login
+                if self._attemp_login("root","analog"):
+                    return True
+                else:
+                    log.info("Attempting to login as analog")
+                    logged_in = self._attemp_login("analog","analog")
             else:
-                log.info("Attempting to login as analog")
-                logged_in = self._attemp_login("analog","analog")
-        else:
-            return True
+                return True
+        except serial.serialutil.SerialTimeoutException as e:
+            log.info(str(e))
         return logged_in
 
     def set_ip_static(self, address, nic="eth0"):

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -164,8 +164,7 @@ class uart(utils):
             try:
                 data = self.com.readline()
                 data = str(data[:-1].decode("ASCII"))
-                data = '[' + datetime.datetime.now().strftime(LOG_FORMAT) + '] ' + data
-                self.pipe_to_log_file(data)
+                self.pipe_to_log_file(str(data))
             except Exception as ex:
                 log.warning("Exception occurred during data decode")
                 log.warning(str(ex))
@@ -495,7 +494,7 @@ class uart(utils):
                             founds.append(True)
                             if indx == len(done_strings)-1:
                                 if restart_log:
-                                    self.start_log()
+                                    self.start_log(logappend=True)
                                 return founds
                             lastd = d[d.find(done_string):]
                             breakbreak = True
@@ -507,7 +506,7 @@ class uart(utils):
                     founds.append(True)
                     if indx == len(done_strings)-1:
                         if restart_log:
-                            self.start_log()
+                            self.start_log(logappend=True)
                         return founds
                     else:
                         lastd = lastd+data
@@ -520,7 +519,7 @@ class uart(utils):
             if t == mt-1:
                 log.info(done_string+" not found in time")
                 if restart_log:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 founds.append(False)
                 return founds
         # if restart_log:
@@ -544,18 +543,18 @@ class uart(utils):
                     if done_string in d:
                         log.info("done found in data")
                         if restart_log:
-                            self.start_log()
+                            self.start_log(logappend=True)
                         return True
             elif done_string in data:
                 log.info("done found in data")
                 if restart_log:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 return True
             else:
                 log.info("Still waiting")
             time.sleep(1)
         if restart_log:
-            self.start_log()
+            self.start_log(logappend=True)
         return False
 
     def _check_for_string_console(self, console_out, string):
@@ -596,17 +595,17 @@ class uart(utils):
             if self._check_for_string_console(data, "zynq-uboot"):
                 log.info("u-boot menu reached")
                 if restart:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 return True
             elif self._check_for_string_console(data, "ZynqMP"):
                 log.info("u-boot menu reached")
                 if restart:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 return True
             time.sleep(0.1)
         log.info("u-boot menu not reached")
         if restart:
-            self.start_log()
+            self.start_log(logappend=True)
         return False
 
     def load_system_uart_from_tftp(self):

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -72,7 +72,7 @@ class uart(utils):
         # Automatically set UART address
         if "auto" in self.address.lower():
             self._auto_set_address()
-        self.com = serial.Serial(self.address, self.baudrate, timeout=0.5)
+        self.com = serial.Serial(self.address, self.baudrate, timeout=0.5, write_timeout=5)
         self.com.reset_input_buffer()
 
     def __del__(self):


### PR DESCRIPTION
This PR includes the following fixes/features:

1. fix hanging com.write by enforcing timeout
2. Pipe uart log when uart listening thread is not running, this enforces complete uart monitoring and logging
3. do a power cylcle rather than jtag reboot to try to recover a hanging jtag device into a running state before running a jtag based operations