### PR TITLE
Fixes for jtag issues and others

### DIFF
--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -163,7 +163,7 @@ class manager:
         try:
             # Flush UART
             self.monitor[0]._read_until_stop()  # Flush
-            self.monitor[0].start_log()
+            self.monitor[0].start_log(logappend=True)
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
             try:
@@ -340,7 +340,7 @@ class manager:
             # wait longer and restart board using jtag
             time.sleep(10)
             self.monitor[0].reinitialize_uart()
-            self.monitor[0].start_log()
+            self.monitor[0].start_log(logappend=True)
             self.jtag.restart_board()
             log.info("Waiting for boot to complete")
             results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=100)
@@ -398,7 +398,7 @@ class manager:
         try:
             # Flush UART
             self.monitor[0]._read_until_stop()  # Flush
-            self.monitor[0].start_log()
+            self.monitor[0].start_log(logappend=True)
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
             try:

--- a/nebula/pdu.py
+++ b/nebula/pdu.py
@@ -57,3 +57,19 @@ class pdu(utils):
             self.pdu_dev.set_outlet_on(self.outlet, True)
         elif self.pdu_type == "vesync":
             self.pdu_dev.outlets[self.outlet].turn_on()
+
+    def power_down_board(self):
+        """ Power Down Board
+        """
+        if self.pdu_type == "cyberpower":
+            self.pdu_dev.set_outlet_on(self.outlet, False)
+        elif self.pdu_type == "vesync":
+            self.pdu_dev.outlets[self.outlet].turn_off()
+
+    def power_up_board(self):
+        """ Power On Board
+        """
+        if self.pdu_type == "cyberpower":
+            self.pdu_dev.set_outlet_on(self.outlet, True)
+        elif self.pdu_type == "vesync":
+            self.pdu_dev.outlets[self.outlet].turn_on()


### PR DESCRIPTION
This PR includes the following fixes/features:
1. Powercycle to retry jtag connection when jtag connection attemp fails.
> There are times JTAG device is not found which can be reloaded when board is powercycled. 

2. add option to boot from sdcard reference if uart is still working
> When trying to recover board and u-boot is still up, the current implementation transfers reference boot files via uart, which will takes a longer time, this feature enables the user through the --sdcard option, to cause nebula.manager to fetch this reference boot files from the SD card itself for faster board recovery execution.

3. fixes
> 1. revert to just jtag reset vs powercycle if executing board_reboot_jtag_uart
> 2. set to always append to log file to not overwrte existing log entry
