### PR TITLE
Downloader update

### DIFF
--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -62,7 +62,12 @@ def get_newest_folder(links):
         raise Exception("No folders found")
     dates.sort(key=lambda date: convert_to_datetime(date))
 
-    if len(listFD(links[-1])) < 20:
+    l = {"hdl":65, "linux":4, "bootpartition":75}
+    for k,v in l.items():
+        if re.search(k, links[-1]):
+            n = v
+    
+    if len(listFD(links[-1])) < n:
         return dates[-2]
     else:
         return dates[-1]

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -62,6 +62,7 @@ def get_newest_folder(links):
         raise Exception("No folders found")
     dates.sort(key=lambda date: convert_to_datetime(date))
 
+    n = 0
     l = {"hdl":65, "linux":4, "bootpartition":75}
     for k,v in l.items():
         if re.search(k, links[-1]):

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -62,7 +62,10 @@ def get_newest_folder(links):
         raise Exception("No folders found")
     dates.sort(key=lambda date: convert_to_datetime(date))
 
-    return dates[-1]
+    if len(listFD(links[-1])) < 20:
+        return dates[-2]
+    else:
+        return dates[-1]
 
 def get_gitsha(branch, link, daily=False):
     server = "artifactory.analog.com"
@@ -136,10 +139,13 @@ def gen_url(ip, branch, folder, filename, url_template):
             return url_template.format(ip, folder, filename)
     else:
         url = url_template.format(ip, "", "", "")
-        if bool(re.search("/hdl/", url_template)):
-            release_folder = get_latest_release(listFD(url))+'/'+"boot_files"
+        if branch == "release" or branch == "release_latest":
+            if bool(re.search("/hdl/", url_template)):
+                release_folder = get_latest_release(listFD(url))+'/'+"boot_files"
+            else:
+                release_folder = get_latest_release(listFD(url))
         else:
-            release_folder = get_latest_release(listFD(url))
+            release_folder = branch if not bool(re.search("/hdl/", url_template)) else branch+'/'+"boot_files"
         url = url_template.format(ip, release_folder, "", "")
         # folder = BUILD_DATE/PROJECT_FOLDER
         folder = get_newest_folder(listFD(url[:-1]))+'/'+str(folder)

--- a/nebula/resources/board_table.yaml
+++ b/nebula/resources/board_table.yaml
@@ -162,6 +162,14 @@ zynq-zc706-adv7511-fmcomms11:
   carrier: ZC706
 zynq-zed-adv7511:
   carrier: Zed-Board
+zynq-zed-adv7511-ad7768:
+  addons:
+  - EVAL-AD7768FMCZ
+  carrier: Zed-Board
+zynq-zed-adv7511-ad7768-1-evb:
+  addons:
+  - EV-AD7768-1FMCZ
+  carrier: Zed-Board
 zynq-zed-adv7511-ad9361-fmcomms2-3:
   addons:
   - AD-FMCOMMS2-EBZ


### PR DESCRIPTION
This pr addresses the following:

1. When a new folder is created while the job is running, the previous script always gets the latest thus creating file not found errors in all projects.

> Solution was to check if there are contents on that latest folder first if it is less than 20 previous folder is to be used. Although this will still cause file not found errors if the job is run mid/almost hdl build is done. The solution only addresses when HDL build just started.

2. Not able to specify release version, ex. 2019_r2. 

> Enable accepting release version i.e. 2019_r2 as a branch, will help when wanting to download from another release version.

3. AD7768 missing on board table.
