### PR TITLE
Updates and Fixes

### DIFF
--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -62,7 +62,12 @@ def get_newest_folder(links):
         raise Exception("No folders found")
     dates.sort(key=lambda date: convert_to_datetime(date))
 
-    if len(listFD(links[-1])) < 20:
+    l = {"hdl":65, "linux":4, "bootpartition":75}
+    for k,v in l.items():
+        if re.search(k, links[-1]):
+            n = v
+    
+    if len(listFD(links[-1])) < n:
         return dates[-2]
     else:
         return dates[-1]

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -62,6 +62,7 @@ def get_newest_folder(links):
         raise Exception("No folders found")
     dates.sort(key=lambda date: convert_to_datetime(date))
 
+    n = 0
     l = {"hdl":65, "linux":4, "bootpartition":75}
     for k,v in l.items():
         if re.search(k, links[-1]):

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -423,7 +423,10 @@ class downloader(utils):
         res = os.path.join(path, "resources", "board_table.yaml")
         with open(res) as f:
             board_configs = yaml.load(f, Loader=yaml.FullLoader)
-
+        
+        if "-v" in design_name:
+            design_name = design_name.split("-v")[0]
+        
         assert design_name in board_configs, "Invalid design name"
 
         reference_boot_folder = self.reference_boot_folder

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -62,7 +62,10 @@ def get_newest_folder(links):
         raise Exception("No folders found")
     dates.sort(key=lambda date: convert_to_datetime(date))
 
-    return dates[-1]
+    if len(listFD(links[-1])) < 20:
+        return dates[-2]
+    else:
+        return dates[-1]
 
 def get_gitsha(branch, link, daily=False):
     server = "artifactory.analog.com"
@@ -136,10 +139,13 @@ def gen_url(ip, branch, folder, filename, url_template):
             return url_template.format(ip, folder, filename)
     else:
         url = url_template.format(ip, "", "", "")
-        if bool(re.search("/hdl/", url_template)):
-            release_folder = get_latest_release(listFD(url))+'/'+"boot_files"
+        if branch == "release" or branch == "release_latest":
+            if bool(re.search("/hdl/", url_template)):
+                release_folder = get_latest_release(listFD(url))+'/'+"boot_files"
+            else:
+                release_folder = get_latest_release(listFD(url))
         else:
-            release_folder = get_latest_release(listFD(url))
+            release_folder = branch if not bool(re.search("/hdl/", url_template)) else branch+'/'+"boot_files"
         url = url_template.format(ip, release_folder, "", "")
         # folder = BUILD_DATE/PROJECT_FOLDER
         folder = get_newest_folder(listFD(url[:-1]))+'/'+str(folder)

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -50,11 +50,7 @@ class manager:
                         except Exception as e:
                             log.info(str(e))
                             log.info('Power cycling board and will attemp jtag connection again.')
-                            self.shutdown_powerdown_board()
-                            # wait for 10 seconds
-                            time.sleep(10)
-                            self.power.power_up_board()
-                            # wait for boot to complete
+                            self.power.power_cycle_board()
                             time.sleep(60)
                             self.jtag = jtag(yamlfilename=configfilename, board_name=board_name)
 

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -38,6 +38,12 @@ class manager:
 
         configs = common.multi_device_check(configs, board_name)
 
+        if "pdu-config" not in configs:
+            configfilename = None
+        else:
+            configfilename = self.configfilename
+        self.power = pdu(yamlfilename=configfilename, board_name=board_name)
+
         self.jtag_use = False
         self.jtag = False
         if "board-config" in configs:
@@ -73,12 +79,6 @@ class manager:
         else:
             configfilename = self.configfilename
         self.net = network(yamlfilename=configfilename, board_name=board_name)
-
-        if "pdu-config" not in configs:
-            configfilename = None
-        else:
-            configfilename = self.configfilename
-        self.power = pdu(yamlfilename=configfilename, board_name=board_name)
 
         self.reference_boot_folder = None
         self.devicetree_subfolder = None

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -163,7 +163,7 @@ class manager:
         try:
             # Flush UART
             self.monitor[0]._read_until_stop()  # Flush
-            self.monitor[0].start_log()
+            self.monitor[0].start_log(logappend=True)
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
             try:
@@ -340,7 +340,7 @@ class manager:
             # wait longer and restart board using jtag
             time.sleep(10)
             self.monitor[0].reinitialize_uart()
-            self.monitor[0].start_log()
+            self.monitor[0].start_log(logappend=True)
             self.jtag.restart_board()
             log.info("Waiting for boot to complete")
             results = self.monitor[0]._read_until_done_multi(done_strings=["U-Boot","Starting kernel","root@analog"], max_time=100)
@@ -398,7 +398,7 @@ class manager:
         try:
             # Flush UART
             self.monitor[0]._read_until_stop()  # Flush
-            self.monitor[0].start_log()
+            self.monitor[0].start_log(logappend=True)
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
             try:

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -128,8 +128,13 @@ class manager:
             self.monitor[0].start_log()
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
-            out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
-            if not out:
+            try:
+                out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
+                if not out:
+                    raise ne.LinuxNotReached
+            except Exception as e:
+                # raise LinuxNotReached for other exceptions
+                log.info(str(e))
                 raise ne.LinuxNotReached
 
             # Get IP over UART
@@ -368,8 +373,13 @@ class manager:
             self.monitor[0].start_log()
             # Check if Linux is accessible
             log.info("Checking if Linux is accessible")
-            out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
-            if not out:
+            try:
+                out = self.monitor[0].get_uart_command_for_linux("uname -a", "Linux")
+                if not out:
+                    raise ne.LinuxNotReached
+            except Exception as e:
+                # raise LinuxNotReached for other exceptions
+                log.info(str(e))
                 raise ne.LinuxNotReached
 
             # Get IP over UART

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -332,7 +332,7 @@ class manager:
             log.warning("UART is unavailable.")
             log.warning(str(ex))
             # wait longer and restart board using jtag
-            time.sleep(10)
+            time.sleep(60)
             self.monitor[0].reinitialize_uart()
             self.monitor[0].start_log(logappend=True)
             self.jtag.restart_board()

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -131,11 +131,9 @@ class manager:
         target = uimagepath.split("/")[1].rstrip()
         if "uImage" in str(uimagepath):
             ref = "zynq-common/" + str(target)
-            done_string = "zynq-uboot"
         else:
             ref = "zynqmp-common/" + str(target)
-            done_string = "ZynqMP"
-        self.monitor[0].copy_reference(ref, target, done_string)
+        self.monitor[0].copy_reference(ref, target)
         
         if self.boot_subfolder is not None:
             ref = self.reference_boot_folder+ '/' +str(self.boot_subfolder)
@@ -143,7 +141,7 @@ class manager:
             ref = self.reference_boot_folder
         target = bootbinpath.split("/")[1].rstrip()
         ref = ref + '/' + str(target)
-        self.monitor[0].copy_reference(ref, target, done_string)
+        self.monitor[0].copy_reference(ref, target)
         
         if self.devicetree_subfolder is not None:
             ref = self.reference_boot_folder+ '/' +str(self.devicetree_subfolder)
@@ -151,7 +149,7 @@ class manager:
             ref = self.reference_boot_folder
         target = devtreepath.split("/")[1].rstrip()
         ref = ref + '/' + str(target)
-        self.monitor[0].copy_reference(ref, target, done_string)
+        self.monitor[0].copy_reference(ref, target)
 
 
     @_release_thread_lock

--- a/nebula/network.py
+++ b/nebula/network.py
@@ -293,3 +293,23 @@ class network(utils):
 
         logs = {"log": all_log, "warn": warn_log, "error": error_log_filetered}
         return len(error_log_filetered) > 0, logs
+
+    def run_diagnostics(self):
+        """ run_diagnostics:
+            execute and download adi_diagnostic report
+
+            return:
+                status: 0 if no errors found, 1 otherwise
+        """
+        #check is ssh is working
+        self.check_board_booted()
+        report_file_name = self.board_name + '_diag_report.tar.bz2'
+        #execute adi_diagnostic_report
+        result = self.run_ssh_command("adi_diagnostic_report --file-name {}".\
+                                      format(report_file_name))
+        if not result.ok:
+            raise Exception("Running diagnostics failed")
+
+        #fetch file
+        self._dl_file(report_file_name)
+        logging.info("Diagnostic report {} collected".format(report_file_name))

--- a/nebula/network.py
+++ b/nebula/network.py
@@ -312,4 +312,4 @@ class network(utils):
 
         #fetch file
         self._dl_file(report_file_name)
-        logging.info("Diagnostic report {} collected".format(report_file_name))
+        log.info("Diagnostic report {} collected".format(report_file_name))

--- a/nebula/network.py
+++ b/nebula/network.py
@@ -96,7 +96,7 @@ class network(utils):
         """ Check if board has network activity with ping, then check SSH working
             This function raises exceptions on failures
         """
-        if self.ping_board():
+        if not self.ping_board():
             raise Exception("Board not booted")
         else:
             logging.info("PING PASSED")
@@ -301,7 +301,7 @@ class network(utils):
             return:
                 status: 0 if no errors found, 1 otherwise
         """
-        #check is ssh is working
+        #check if can connect to board
         self.check_board_booted()
         report_file_name = self.board_name + '_diag_report.tar.bz2'
         #execute adi_diagnostic_report

--- a/nebula/pdu.py
+++ b/nebula/pdu.py
@@ -57,3 +57,19 @@ class pdu(utils):
             self.pdu_dev.set_outlet_on(self.outlet, True)
         elif self.pdu_type == "vesync":
             self.pdu_dev.outlets[self.outlet].turn_on()
+
+    def power_down_board(self):
+        """ Power Down Board
+        """
+        if self.pdu_type == "cyberpower":
+            self.pdu_dev.set_outlet_on(self.outlet, False)
+        elif self.pdu_type == "vesync":
+            self.pdu_dev.outlets[self.outlet].turn_off()
+
+    def power_up_board(self):
+        """ Power On Board
+        """
+        if self.pdu_type == "cyberpower":
+            self.pdu_dev.set_outlet_on(self.outlet, True)
+        elif self.pdu_type == "vesync":
+            self.pdu_dev.outlets[self.outlet].turn_on()

--- a/nebula/resources/board_table.yaml
+++ b/nebula/resources/board_table.yaml
@@ -132,6 +132,14 @@ zynq-zc706-adv7511-adrv9375:
   addons:
   - ADRV9375
   carrier: ZC706
+zynq-zc706-adv7511-adrv9002:
+  addons:
+  - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
+  carrier: ZC706
+zynq-zc706-adv7511-adrv9002-rx2tx2:
+  addons:
+  - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
+  carrier: ZC706
 zynq-zc706-adv7511-fmcdaq2:
   addons:
   - AD-FMCDAQ2-EBZ
@@ -171,6 +179,10 @@ zynq-zed-adv7511-adrv9002:
   addons:
   - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
   carrier: Zed-Board
+zynq-zed-adv7511-adrv9002-rx2tx2:
+  addons:
+  - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
+  carrier: Zed-Board
 zynq-zed-adv7511-cn0363:
   addons:
   - EVAL-CN0363-PMDZ
@@ -201,6 +213,10 @@ zynqmp-zcu102-rev10-ad9364-fmcomms4:
   - AD-FMCOMMS4-EBZ
   carrier: ZCU102
 zynqmp-zcu102-rev10-adrv9002:
+  addons:
+  - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
+  carrier: ZCU102
+zynqmp-zcu102-rev10-adrv9002-rx2tx2:
   addons:
   - ADRV9002NP/W1/PCBZ ADRV9002NP/W2/PCBZ
   carrier: ZCU102

--- a/nebula/resources/board_table.yaml
+++ b/nebula/resources/board_table.yaml
@@ -162,6 +162,14 @@ zynq-zc706-adv7511-fmcomms11:
   carrier: ZC706
 zynq-zed-adv7511:
   carrier: Zed-Board
+zynq-zed-adv7511-ad7768:
+  addons:
+  - EVAL-AD7768FMCZ
+  carrier: Zed-Board
+zynq-zed-adv7511-ad7768-1-evb:
+  addons:
+  - EV-AD7768-1FMCZ
+  carrier: Zed-Board
 zynq-zed-adv7511-ad9361-fmcomms2-3:
   addons:
   - AD-FMCOMMS2-EBZ

--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -96,6 +96,11 @@ uart-config:
     default: my.log
     help: "Output UART logfilename"
     optional: False
+  field_4:
+    name: uboot_done_string
+    default: zynq-uboot>
+    help: "Uboot menu prompt"
+    optional: True
 system-config:
   field_1:
     name: tftpserverip

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -731,11 +731,32 @@ def update_boot_files(
         bootbinpath=bootbinpath, uimagepath=uimagepath, devtreepath=devtreepath
     )
 
+@task(
+    help={
+        "ip": "IP address of board. Default from yaml",
+        "user": "Board username. Default: root",
+        "password": "Password for board. Default: analog",
+        "board_name": "Name of DUT design (Ex: zynq-zc706-adv7511-fmcdaq2). Require for multi-device config files",
+    }
+)
+def run_diagnostics(
+    c,
+    ip=None,
+    user="root",
+    password="analog",
+    board_name=None,
+):
+    """ Run adi_diagnostics and fetch result"""
+    n = nebula.network(
+        dutip=ip, dutusername=user, dutpassword=password, board_name=board_name
+    )
+    n.run_diagnostics()
 
 net = Collection("net")
 net.add_task(restart_board)
 net.add_task(update_boot_files)
 net.add_task(check_dmesg)
+net.add_task(run_diagnostics)
 
 #############################################
 @task(

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -83,7 +83,7 @@ class uart(utils):
             self.com.close()
 
     def is_open(self):
-        self.com.is_open()
+        return self.com.is_open
 
     def reinitialize_uart(self):
         log.info("Reinitializing UART")

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -82,6 +82,9 @@ class uart(utils):
         if self.com:
             self.com.close()
 
+    def is_open(self):
+        self.com.is_open()
+
     def reinitialize_uart(self):
         log.info("Reinitializing UART")
         if self.com:

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -307,28 +307,32 @@ class uart(utils):
         return logged_in
 
     def _check_for_login(self):
-        for _ in range(2):  # Check at least twice
-            cmd = ""
-            self._write_data(cmd)
-            data = self._read_for_time(period=1)
-            needs_login = False
-            for d in data:
-                if isinstance(d, list):
-                    for c in d:
-                        c = c.replace("\r", "")
-                        log.info(c)
-                        if "login:" in c:
-                            needs_login = True
         logged_in=False
-        if needs_login:
-            # Do login
-            if self._attemp_login("root","analog"):
-                return True
+        try:
+            for _ in range(2):  # Check at least twice
+                cmd = ""
+                self._write_data(cmd)
+                data = self._read_for_time(period=1)
+                needs_login = False
+                for d in data:
+                    if isinstance(d, list):
+                        for c in d:
+                            c = c.replace("\r", "")
+                            log.info(c)
+                            if "login:" in c:
+                                needs_login = True
+            
+            if needs_login:
+                # Do login
+                if self._attemp_login("root","analog"):
+                    return True
+                else:
+                    log.info("Attempting to login as analog")
+                    logged_in = self._attemp_login("analog","analog")
             else:
-                log.info("Attempting to login as analog")
-                logged_in = self._attemp_login("analog","analog")
-        else:
-            return True
+                return True
+        except serial.serialutil.SerialTimeoutException as e:
+            log.info(str(e))
         return logged_in
 
     def set_ip_static(self, address, nic="eth0"):

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -164,8 +164,7 @@ class uart(utils):
             try:
                 data = self.com.readline()
                 data = str(data[:-1].decode("ASCII"))
-                data = '[' + datetime.datetime.now().strftime(LOG_FORMAT) + '] ' + data
-                self.pipe_to_log_file(data)
+                self.pipe_to_log_file(str(data))
             except Exception as ex:
                 log.warning("Exception occurred during data decode")
                 log.warning(str(ex))
@@ -495,7 +494,7 @@ class uart(utils):
                             founds.append(True)
                             if indx == len(done_strings)-1:
                                 if restart_log:
-                                    self.start_log()
+                                    self.start_log(logappend=True)
                                 return founds
                             lastd = d[d.find(done_string):]
                             breakbreak = True
@@ -507,7 +506,7 @@ class uart(utils):
                     founds.append(True)
                     if indx == len(done_strings)-1:
                         if restart_log:
-                            self.start_log()
+                            self.start_log(logappend=True)
                         return founds
                     else:
                         lastd = lastd+data
@@ -520,7 +519,7 @@ class uart(utils):
             if t == mt-1:
                 log.info(done_string+" not found in time")
                 if restart_log:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 founds.append(False)
                 return founds
         # if restart_log:
@@ -544,18 +543,18 @@ class uart(utils):
                     if done_string in d:
                         log.info("done found in data")
                         if restart_log:
-                            self.start_log()
+                            self.start_log(logappend=True)
                         return True
             elif done_string in data:
                 log.info("done found in data")
                 if restart_log:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 return True
             else:
                 log.info("Still waiting")
             time.sleep(1)
         if restart_log:
-            self.start_log()
+            self.start_log(logappend=True)
         return False
 
     def _check_for_string_console(self, console_out, string):
@@ -596,17 +595,17 @@ class uart(utils):
             if self._check_for_string_console(data, "zynq-uboot"):
                 log.info("u-boot menu reached")
                 if restart:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 return True
             elif self._check_for_string_console(data, "ZynqMP"):
                 log.info("u-boot menu reached")
                 if restart:
-                    self.start_log()
+                    self.start_log(logappend=True)
                 return True
             time.sleep(0.1)
         log.info("u-boot menu not reached")
         if restart:
-            self.start_log()
+            self.start_log(logappend=True)
         return False
 
     def load_system_uart_from_tftp(self):

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -72,7 +72,7 @@ class uart(utils):
         # Automatically set UART address
         if "auto" in self.address.lower():
             self._auto_set_address()
-        self.com = serial.Serial(self.address, self.baudrate, timeout=0.5)
+        self.com = serial.Serial(self.address, self.baudrate, timeout=0.5, write_timeout=5)
         self.com.reset_input_buffer()
 
     def __del__(self):


### PR DESCRIPTION
This PR includes the following changes.

  network:
  1. Added support for executing and fetching diagnostic (reports) to dut using the network.
  
  manager:
  1. Fixed hanging com.write by enforcing timeout
  2. Powercycle to retry jtag connection when jtag connection attemp fails.
  3. add option to boot from sdcard reference if uart is still working
  4. set to always append to log file to not overwrite existing log entry
  5. Parametrize uboot menu prompt done string for more robust uboot prompt detection
  6. reinitialize jtag first before uart
  7. initialize power before jtag to do powercycling if jtag connection attemp failed
  
  uart:
  1. Pipe uart log when uart listening thread is not running, this enforces complete uart monitoring and logging
  2. wait a littler longer when re-intializing uart
  
  pdu:
  1. added power_down and power_up routines
  
  template_gen:
  1. add uboot_done_string field under uart-config
  
  downloader:
  1. Added support to handle board variants. ex. adrv9002
  2. Enable accepting release version i.e. 2019_r2 as a branch
  3. Specific folder count check to capture each cases

 task:
 1. Add run_diagnostics task

 board_table:
 1. add adrv9002 variants