### PR TITLE
Nebula-netbox support

### DIFF
--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -283,6 +283,9 @@ class helper:
         netbox_token=None,
         jenkins_agent=None,
         board_name=None,
+        devices_status=None,
+        devices_role=None,
+        devices_tag=None
     ):
         # Read in template
         path = pathlib.Path(__file__).parent.absolute()
@@ -305,7 +308,13 @@ class helper:
             nbd = NetboxDevice(ni, device_name=board_name)
             outconfig = nbd.to_config(config)
         else:
-            nbds = NetboxDevices(ni, agent=jenkins_agent)
+            nbds = NetboxDevices(
+                ni,
+                status=devices_status,
+                role=devices_role,
+                agent=jenkins_agent,
+                tag=devices_tag
+            )
             outconfig = nbds.generate_config(config)
 
         self._write_config_file(filename=outfile, outconfig=outconfig)

--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -288,8 +288,12 @@ class helper:
         path = pathlib.Path(__file__).parent.absolute()
         template = os.path.join(path, "resources", "template_gen.yaml")
         ni = netbox(
-            ip=netbox_ip, port=netbox_port, base_url=netbox_baseurl, token=netbox_token
-        )
+            ip=netbox_ip,
+            port=netbox_port,
+            base_url=netbox_baseurl,
+            token=netbox_token,
+            load_config=False
+            )
         outconfig = dict()
         config = dict()
 

--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -8,9 +8,7 @@ import nebula.errors as ne
 import netifaces
 import yaml
 from nebula.common import multi_device_check
-from nebula.netbox import netbox
-from nebula.netbox import NetboxDevices
-from nebula.netbox import NetboxDevice
+from nebula.netbox import NetboxDevice, NetboxDevices, netbox
 
 LINUX_DEFAULT_PATH = "/etc/default/nebula"
 WINDOWS_DEFAULT_PATH = "C:\\nebula\\nebula.yaml"
@@ -284,32 +282,29 @@ class helper:
         netbox_baseurl=None,
         netbox_token=None,
         jenkins_agent=None,
-        board_name=None
+        board_name=None,
     ):
         # Read in template
         path = pathlib.Path(__file__).parent.absolute()
-        template = os.path.join(path, "resources", "template_gen.yaml")        
+        template = os.path.join(path, "resources", "template_gen.yaml")
         ni = netbox(
-            ip=netbox_ip,
-            port=netbox_port,
-            base_url=netbox_baseurl,
-            token=netbox_token)
+            ip=netbox_ip, port=netbox_port, base_url=netbox_baseurl, token=netbox_token
+        )
         outconfig = dict()
         config = dict()
 
         # load config from file
-        with open(template, 'r') as f:
+        with open(template, "r") as f:
             config = yaml.safe_load(f)
 
         if board_name:
-            nbd = NetboxDevice(ni,device_name=board_name)
+            nbd = NetboxDevice(ni, device_name=board_name)
             outconfig = nbd.to_config(config)
         else:
-            nbds = NetboxDevices(ni,agent=jenkins_agent)
+            nbds = NetboxDevices(ni, agent=jenkins_agent)
             outconfig = nbds.generate_config(config)
 
-        self._write_config_file(filename=outfile,outconfig=outconfig)
-        
+        self._write_config_file(filename=outfile, outconfig=outconfig)
 
     def _write_config_file(self, filename, outconfig):
         with open(filename, "w") as file:

--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -285,7 +285,7 @@ class helper:
         board_name=None,
         devices_status=None,
         devices_role=None,
-        devices_tag=None
+        devices_tag=None,
     ):
         # Read in template
         path = pathlib.Path(__file__).parent.absolute()
@@ -295,8 +295,8 @@ class helper:
             port=netbox_port,
             base_url=netbox_baseurl,
             token=netbox_token,
-            load_config=False
-            )
+            load_config=False,
+        )
         outconfig = dict()
         config = dict()
 
@@ -313,7 +313,7 @@ class helper:
                 status=devices_status,
                 role=devices_role,
                 agent=jenkins_agent,
-                tag=devices_tag
+                tag=devices_tag,
             )
             outconfig = nbds.generate_config(config)
 

--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -294,14 +294,19 @@ class helper:
             base_url=netbox_baseurl,
             token=netbox_token)
         outconfig = dict()
+        config = dict()
+
+        # load config from file
+        with open(template, 'r') as f:
+            config = yaml.safe_load(f)
+
         if board_name:
-            with open(template, 'r') as f:
-                config = yaml.safe_load(f)
-                nbd = NetboxDevice(ni,device_name=board_name)
-                outconfig = nbd.to_config(config)
+            nbd = NetboxDevice(ni,device_name=board_name)
+            outconfig = nbd.to_config(config)
         else:
-            nbvs = NetboxDevices(ni,agent=jenkins_agent)
-            outconfig = nbvs.generate_config(template)
+            nbds = NetboxDevices(ni,agent=jenkins_agent)
+            outconfig = nbds.generate_config(config)
+
         self._write_config_file(filename='nebula',outconfig=outconfig)
         
 

--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -277,7 +277,8 @@ class helper:
         print("Pew pew... all set")
 
     def create_config_from_netbox(
-        self, 
+        self,
+        outfile="nebula",
         netbox_ip="localhost",
         netbox_port=None,
         netbox_baseurl=None,
@@ -307,7 +308,7 @@ class helper:
             nbds = NetboxDevices(ni,agent=jenkins_agent)
             outconfig = nbds.generate_config(config)
 
-        self._write_config_file(filename='nebula',outconfig=outconfig)
+        self._write_config_file(filename=outfile,outconfig=outconfig)
         
 
     def _write_config_file(self, filename, outconfig):

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -363,7 +363,7 @@ class NetboxDevice:
 class NetboxDevices:
     """List of NetboxDevice"""
 
-    def __init__(self, ni, status="active", role="fpga_dut", agent=None):
+    def __init__(self, ni, status="active", role="fpga_dut", agent=None, tag=None):
         # get cluster agent
         dut_bank_id = None
         for cluster in ni.get_clusters():
@@ -387,10 +387,15 @@ class NetboxDevices:
 
         kwargs["role_name"] = role
         kwargs["status"] = status
+        kwargs["tag"] = tag
 
         devices_names = ni.get_devices_name(include_variants=True, **kwargs)
 
+        self.devices_name = devices_names
         self.devices = [NetboxDevice(ni, dev) for dev in devices_names]
+
+    def get_devices_names(self):
+        return self.devices_name
 
     def generate_config(self, template=None):
         template_dict = dict()

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -119,24 +119,38 @@ class netbox(utils):
         return devices_names
 
     def get_devices(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.dcim.devices.all()]
         return [dict(device) for device in self.nb.dcim.devices.filter(**filters)]
 
     def get_console_ports(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.dcim.console_ports.all()]
         return [dict(cp) for cp in self.nb.dcim.console_ports.filter(**filters)]
 
     def get_interfaces(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.dcim.interfaces.all()]
         return [dict(inf) for inf in self.nb.dcim.interfaces.filter(**filters)]
 
     def get_ip_addresses(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.ipam.ip_addresses.all()]
         return [dict(ip) for ip in self.nb.ipam.ip_addresses.filter(**filters)]
 
     def get_power_ports(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.dcim.power_ports.all()]
         return [dict(pow) for pow in self.nb.dcim.power_ports.filter(**filters)]
 
     def get_power_outlets(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.dcim.power_outlets.all()]
         return [dict(out) for out in self.nb.dcim.power_outlets.filter(**filters)]
 
     def get_clusters(self, **filters):
+        if not filters:
+            return [dict(device) for device in self.nb.virtualization.clusters.all()]
         return [dict(out) for out in self.nb.virtualization.clusters.filter(**filters)]
 
 

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -72,13 +72,19 @@ class netbox(utils):
         base_url="",
         yamlfilename=None,
         board_name=None,
+        load_config=True
     ):
         port = ":" + str(port) if port else ""
         base_url = "/" + str(base_url) if base_url else ""
+        self.netbox_server = ip
+        self.netbox_server_port = port
+        self.netbox_api_token = token
+        self.netbox_base_url = base_url
         self.nb = pynetbox.api(f"http://{ip}{port}{base_url}", token=token)
-        self.update_defaults_from_yaml(
-            yamlfilename, __class__.__name__, board_name=board_name
-        )
+        if load_config:
+            self.update_defaults_from_yaml(
+                yamlfilename, __class__.__name__, board_name=board_name
+            )
 
     def interface(self):
         return self.nb

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -1,6 +1,55 @@
+from re import L
+from numpy import isin
+import logging
 import pynetbox
 from nebula.common import utils
+import yaml
+import json
+import os
+import pathlib
 
+log = logging.getLogger(__name__)
+
+def obj_dic(d):
+    '''Convert dictionary to object'''
+    top = type('new', (object,), d)
+    seqs = tuple, list, set, frozenset
+    for i, j in d.items():
+        if isinstance(j, dict):
+            setattr(top, i, obj_dic(j))
+        elif isinstance(j, seqs):
+            setattr(top, i, 
+                type(j)(obj_dic(sj) if isinstance(sj, dict) else sj for sj in j))
+        else:
+            setattr(top, i, j)
+    return top
+
+def todict(obj, classkey=None):
+    '''Convert object to dictionary'''
+    if isinstance(obj, dict):
+        data = {}
+        for (k, v) in obj.items():
+            data[k] = todict(v, classkey)
+        return data
+    elif hasattr(obj, "_ast"):
+        return todict(obj._ast())
+    elif hasattr(obj, "__iter__") and not isinstance(obj, str):
+        return [todict(v, classkey) for v in obj]
+    elif hasattr(obj, "__dict__"):
+        data = dict([(key, todict(value, classkey)) 
+            for key, value in obj.__dict__.items() 
+            if not callable(value) and not key.startswith('_')])
+        if classkey is not None and hasattr(obj, "__class__"):
+            data[classkey] = obj.__class__.__name__
+        return data
+    else:
+        return obj
+
+def ddepth(d):
+    '''Return depth of a dictionary'''
+    if isinstance(d, dict):
+        return 1 + (max(map(ddepth, d.values())) if d else 0)
+    return 0
 
 class netbox(utils):
     """NetBox interface"""
@@ -10,13 +59,19 @@ class netbox(utils):
         ip="localhost",
         port=8000,
         token="0123456789abcdef0123456789abcdef01234567",
+        base_url="",
         yamlfilename=None,
         board_name=None,
     ):
-        self.nb = pynetbox.api(f"http://{ip}:{port}", token=token)
+        port = ":" + str(port) if port else ""
+        base_url = "/" + str(base_url) if base_url else ""
+        self.nb = pynetbox.api(f"http://{ip}{port}{base_url}", token=token)
         self.update_defaults_from_yaml(
             yamlfilename, __class__.__name__, board_name=board_name
         )
+
+    def interface(self):
+        return self.nb
 
     def get_mac_from_asset_tag(self, asset_tag):
         dev = self.nb.dcim.devices.get(asset_tag=asset_tag)
@@ -24,3 +79,285 @@ class netbox(utils):
             raise Exception(f"No devices for with asset tag: {asset_tag}")
         intf = self.nb.dcim.interfaces.get(device_id=dev.id)
         return intf.mac_address
+
+    def get_devices_name(self, include_variants=False, **filters):
+        devices = self.nb.dcim.devices.filter(**filters)
+        devices_names = list()
+        for device in devices:
+            device_dict = dict(device)
+            if include_variants:
+                if 'variants' in device_dict['config_context']:
+                    for type in device_dict['config_context']['variants']:
+                        if ddepth(device_dict['config_context']['variants'][type]) == 3:
+                            for variant in device_dict['config_context']['variants'][type]:
+                                devices_names.append(device_dict['name'] + '-' + type + '-v' + variant)
+                        else:
+                            # type is a variant
+                            devices_names.append(device_dict['name'] + '-v' + type)
+                    continue
+            devices_names.append(device_dict['name'])
+        return devices_names
+
+    def get_devices(self, **filters):
+        return [ dict(device) for device in \
+            self.nb.dcim.devices.filter(**filters)]
+
+    def get_console_ports(self, **filters):
+        return [ dict(cp) for cp in \
+            self.nb.dcim.console_ports.filter(**filters) ]
+
+    def get_interfaces(self, **filters):
+        return [ dict(inf) for inf in \
+            self.nb.dcim.interfaces.filter(**filters) ]
+
+    def get_ip_addresses(self, **filters):
+        return [ dict(ip) for ip in \
+                self.nb.ipam.ip_addresses.filter(**filters) ]
+
+    def get_power_ports(self, **filters):
+        return [ dict(pow) for pow in \
+                self.nb.dcim.power_ports.filter(**filters) ]
+
+    def get_power_outlets(self, **filters):
+        return [ dict(out) for out in \
+                self.nb.dcim.power_outlets.filter(**filters) ]
+
+    def get_clusters(self, **filters):
+        return [ dict(out) for out in \
+                self.nb.virtualization.clusters.filter(**filters) ]
+
+class NetboxDevice():
+    ''' Netbox Device Model'''
+
+    def __init__(self, netbox_interface, device_name, dtype=None, variant=None):
+
+        self.data = dict()
+        self.nbi = netbox_interface
+        self.data_object = object()
+        self.type_list = ['rx2tx2']
+        self.device_type = None
+        self.device_variant = None
+
+        log.info("Creating model for {}".format(device_name))
+
+        #  check if device is variant
+        if len(device_name.split('-v')) == 2:
+            if not variant:
+                variant = device_name.split('-v')[1]
+            device_name = device_name.split('-v')[0]
+
+        if not dtype:
+            if device_name.split('-')[-1] in self.type_list:
+                dtype = device_name.split('-')[-1]
+
+        if dtype:
+            device_name = device_name.split('-'+dtype)[0]
+
+        dev_raw = self.nbi.get_devices(name=device_name)
+        if len(dev_raw) != 1:
+            raise Exception(f"Either {device_name} is not found or has multiple netbox entry")
+        
+        self.data.update({"devices": dev_raw[0]})
+
+        # get associated console ports
+        cp_raw = self.nbi.get_console_ports(
+                device_id=self.data["devices"]["id"]
+            )
+        self.data['devices'].update({"console_ports":dict()})
+        for port in cp_raw:
+            self.data['devices']['console_ports'].update({port['name']: port})
+
+        # get associated interfaces
+        inf_raw = self.nbi.get_interfaces(
+                device_id=self.data["devices"]["id"]
+            )
+        self.data['devices'].update({"interfaces":dict()})
+        for inf in inf_raw:
+            inf_name = inf['name']
+            if bool(inf['mgmt_only']):
+                inf_name = "mgmt"
+            
+            # add ip information
+            ip_raw = self.nbi.get_ip_addresses(interface_id=inf["id"])
+            inf.update({"ip":ip_raw[0]})
+            self.data['devices']['interfaces'].update({inf_name: inf})
+
+        # get associated power ports
+        pow_raw = self.nbi.get_power_ports(device_id=self.data["devices"]["id"])
+        self.data['devices'].update({"power_ports":dict()})
+        for pow in pow_raw:
+            #get associated oulet
+            outlet_id = pow['connected_endpoint']['id']
+            outlet = self.nbi.get_power_outlets(id=outlet_id)
+            pow['connected_endpoint']['outlet'] = outlet[0]['custom_fields']['outlet']
+
+            # get ip of pdu
+            pdu_raw = self.nbi.get_devices(
+                id=pow['connected_endpoint']['device']['id']
+            )
+            pow['pdus'] = list()
+            for pdu in pdu_raw:
+                pow['pdus'].append(pdu)
+
+            self.data['devices']['power_ports'].update({'input': pow})
+
+        # update for type/variant
+        if 'variants' in self.data['devices']['config_context']:
+            variants_dict = self.data['devices']['config_context']['variants']
+
+            if dtype:
+                if dtype in variants_dict:
+                    log.info(f"Processing for type {dtype}")
+                    variants_dict = variants_dict[dtype]
+                    device_name = device_name + '-' + dtype
+                else:
+                    raise Exception(f"Type {dtype} not defined")
+
+            if variant:
+                if variant in variants_dict:
+                    log.info(f"Processing for variant {variant}")
+                    if variants_dict[variant] == "default":
+                        self.data['devices']['variant_data'] = None
+                    else:
+                        self.data['devices']['variant_data'] = json.dumps(variants_dict[variant])
+                    device_name = device_name + '-v' + variant
+                else:
+                    raise Exception(f"Variant {variant} not defined")
+
+            self.data['devices']['name'] = device_name
+
+        data_object = obj_dic(self.data)
+        self.__dict__.update(data_object.__dict__.copy())
+
+    def to_config(self, template):
+        log.info("Generating config for {}".format(self.devices.name))
+        template_dict= dict()
+        required_fields = list()
+        if template:
+            for name,section in template.items():
+                template_dict[name] = dict()
+                for field in section.values():
+                    try:
+                        value = None
+                        if 'netbox_field' in field:
+                            value = eval('self.'+field['netbox_field'])
+
+                            # check for Null/None values
+                            if str(value) == "None":
+                                raise Exception(
+                                    "None value not valid for {}".\
+                                        format(field['name'])
+                                )
+
+                            # check if value is a valid option
+                            if 'options' in field and str(value) not in field['options']:
+                                if 'optional' in field and bool(field['optional']) == False:
+                                    raise Exception("value {} not in valid options {}".\
+                                        format(value, field['options']))
+
+                            # convert value to list if csv
+                            if isinstance(value, str) and len(value.split(',')) > 1:
+                                value = value.split(',')
+
+                            # extract ip from cidr
+                            if isinstance(value, str) and len(value.split('/')) == 2:
+                                value = value.split('/')[0]
+                        else:
+                            raise Exception("netbox_field undefined for {}:{}".\
+                                format(name, field['name']))
+
+                        template_dict[name][field['name']] = value
+
+                    except Exception as ex:
+                        if 'optional' in field and bool(field['optional']) == True:
+                            log.warning(str(ex)+'.'+' Skipping since optional')
+                            continue
+
+                        if 'default' in field:
+                            template_dict[name][field['name']] = field['default']
+                            log.warning(str(ex)+'.'+' Will try to use default')
+                            continue
+
+                        log.error('Cannot parse {}'.format(field['name']))
+                        raise Exception("Template mapping failed")
+                    finally:
+                        # check if field had some required fields
+                        if 'requires' in field:
+                                answer = field['requires'].split(':')[0]
+                                if value == answer:
+                                    for rf in field['requires'].split(':')[1].split(','):
+                                        required_fields.append((name,rf))
+                
+                # remove empty sections
+                if not template_dict[name]:
+                    del template_dict[name]
+
+        # check for required fields
+        for r_sec, r_field in required_fields:
+            try:
+                value = template_dict[r_sec][r_field]
+                log.info('{}{} with value {} exists'.\
+                    format(r_sec,r_field,value))
+            except:
+                log.error("A required field {}{} cannot be found".\
+                    format(r_sec, r_field))
+                raise Exception("Template mapping failed")
+
+        # update for variant
+        if hasattr(self.devices,'variant_data'):
+            if self.devices.variant_data:
+                for sctn_name, fld in json.loads(self.devices.variant_data).items():
+                    for fld_name, fld_val in fld.items():
+                        if not sctn_name in template_dict:
+                            template_dict[sctn_name] = dict()
+                        template_dict[sctn_name][fld_name] = fld_val
+
+        return template_dict
+
+class NetboxDevices():
+    ''' List of NetboxDevice '''
+    def __init__(self, ni, status="active", role='fpga_dut', agent=None):
+        # get cluster agent
+        dut_bank_id = None
+        for cluster in ni.get_clusters():
+            if 'custom_fields' in cluster \
+                and 'cluster_agent' in cluster['custom_fields']:
+                if cluster['custom_fields']['cluster_agent'] == agent:
+                    dut_bank_id = cluster['id']
+                    break
+            else:
+                log.warning("cluster agent not defined")
+ 
+        if agent and not dut_bank_id:
+            raise Exception(f"Cannot find agent {agent}")
+
+        #get devices
+        kwargs = dict()
+        if dut_bank_id:
+            kwargs['cluster_id'] = dut_bank_id
+        
+        kwargs['role_name'] = role
+        kwargs['status'] = status
+        
+        devices_names = ni.get_devices_name(
+                    include_variants=True, 
+                    **kwargs
+                )
+
+        self.devices = [ NetboxDevice(ni, dev) for dev in devices_names ]
+
+
+    def generate_config(self, template_file=None):
+        template_dict = dict()
+        path = pathlib.Path(__file__).parent.absolute()
+
+        if not template_file:
+            template_file = os.path.join(path, "resources", "template_gen.yaml")
+
+        with open(template_file, 'r') as f:
+            template = yaml.safe_load(f)
+            for dev in self.devices:
+                template_dict.update({dev.devices.name: dev.to_config(template)})
+
+        return template_dict
+

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -1,31 +1,35 @@
-from re import L
-from numpy import isin
-import logging
-import pynetbox
-from nebula.common import utils
-import yaml
 import json
+import logging
 import os
 import pathlib
+from re import L
+
+import pynetbox
+import yaml
+from nebula.common import utils
+from numpy import isin
 
 log = logging.getLogger(__name__)
 
+
 def obj_dic(d):
-    '''Convert dictionary to object'''
-    top = type('new', (object,), d)
+    """Convert dictionary to object"""
+    top = type("new", (object,), d)
     seqs = tuple, list, set, frozenset
     for i, j in d.items():
         if isinstance(j, dict):
             setattr(top, i, obj_dic(j))
         elif isinstance(j, seqs):
-            setattr(top, i, 
-                type(j)(obj_dic(sj) if isinstance(sj, dict) else sj for sj in j))
+            setattr(
+                top, i, type(j)(obj_dic(sj) if isinstance(sj, dict) else sj for sj in j)
+            )
         else:
             setattr(top, i, j)
     return top
 
+
 def todict(obj, classkey=None):
-    '''Convert object to dictionary'''
+    """Convert object to dictionary"""
     if isinstance(obj, dict):
         data = {}
         for (k, v) in obj.items():
@@ -36,20 +40,26 @@ def todict(obj, classkey=None):
     elif hasattr(obj, "__iter__") and not isinstance(obj, str):
         return [todict(v, classkey) for v in obj]
     elif hasattr(obj, "__dict__"):
-        data = dict([(key, todict(value, classkey)) 
-            for key, value in obj.__dict__.items() 
-            if not callable(value) and not key.startswith('_')])
+        data = dict(
+            [
+                (key, todict(value, classkey))
+                for key, value in obj.__dict__.items()
+                if not callable(value) and not key.startswith("_")
+            ]
+        )
         if classkey is not None and hasattr(obj, "__class__"):
             data[classkey] = obj.__class__.__name__
         return data
     else:
         return obj
 
+
 def ddepth(d):
-    '''Return depth of a dictionary'''
+    """Return depth of a dictionary"""
     if isinstance(d, dict):
         return 1 + (max(map(ddepth, d.values())) if d else 0)
     return 0
+
 
 class netbox(utils):
     """NetBox interface"""
@@ -86,130 +96,124 @@ class netbox(utils):
         for device in devices:
             device_dict = dict(device)
             if include_variants:
-                if 'variants' in device_dict['config_context']:
-                    for type in device_dict['config_context']['variants']:
-                        if ddepth(device_dict['config_context']['variants'][type]) == 3:
-                            for variant in device_dict['config_context']['variants'][type]:
-                                devices_names.append(device_dict['name'] + '-' + type + '-v' + variant)
+                if "variants" in device_dict["config_context"]:
+                    for type in device_dict["config_context"]["variants"]:
+                        if ddepth(device_dict["config_context"]["variants"][type]) == 3:
+                            for variant in device_dict["config_context"]["variants"][
+                                type
+                            ]:
+                                devices_names.append(
+                                    device_dict["name"] + "-" + type + "-v" + variant
+                                )
                         else:
                             # type is a variant
-                            devices_names.append(device_dict['name'] + '-v' + type)
+                            devices_names.append(device_dict["name"] + "-v" + type)
                     continue
-            devices_names.append(device_dict['name'])
+            devices_names.append(device_dict["name"])
         return devices_names
 
     def get_devices(self, **filters):
-        return [ dict(device) for device in \
-            self.nb.dcim.devices.filter(**filters)]
+        return [dict(device) for device in self.nb.dcim.devices.filter(**filters)]
 
     def get_console_ports(self, **filters):
-        return [ dict(cp) for cp in \
-            self.nb.dcim.console_ports.filter(**filters) ]
+        return [dict(cp) for cp in self.nb.dcim.console_ports.filter(**filters)]
 
     def get_interfaces(self, **filters):
-        return [ dict(inf) for inf in \
-            self.nb.dcim.interfaces.filter(**filters) ]
+        return [dict(inf) for inf in self.nb.dcim.interfaces.filter(**filters)]
 
     def get_ip_addresses(self, **filters):
-        return [ dict(ip) for ip in \
-                self.nb.ipam.ip_addresses.filter(**filters) ]
+        return [dict(ip) for ip in self.nb.ipam.ip_addresses.filter(**filters)]
 
     def get_power_ports(self, **filters):
-        return [ dict(pow) for pow in \
-                self.nb.dcim.power_ports.filter(**filters) ]
+        return [dict(pow) for pow in self.nb.dcim.power_ports.filter(**filters)]
 
     def get_power_outlets(self, **filters):
-        return [ dict(out) for out in \
-                self.nb.dcim.power_outlets.filter(**filters) ]
+        return [dict(out) for out in self.nb.dcim.power_outlets.filter(**filters)]
 
     def get_clusters(self, **filters):
-        return [ dict(out) for out in \
-                self.nb.virtualization.clusters.filter(**filters) ]
+        return [dict(out) for out in self.nb.virtualization.clusters.filter(**filters)]
 
-class NetboxDevice():
-    ''' Netbox Device Model'''
+
+class NetboxDevice:
+    """Netbox Device Model"""
 
     def __init__(self, netbox_interface, device_name, dtype=None, variant=None):
 
         self.data = dict()
         self.nbi = netbox_interface
         self.data_object = object()
-        self.type_list = ['rx2tx2']
+        self.type_list = ["rx2tx2"]
         self.device_type = None
         self.device_variant = None
 
         log.info("Creating model for {}".format(device_name))
 
         #  check if device is variant
-        if len(device_name.split('-v')) == 2:
+        if len(device_name.split("-v")) == 2:
             if not variant:
-                variant = device_name.split('-v')[1]
-            device_name = device_name.split('-v')[0]
+                variant = device_name.split("-v")[1]
+            device_name = device_name.split("-v")[0]
 
         if not dtype:
-            if device_name.split('-')[-1] in self.type_list:
-                dtype = device_name.split('-')[-1]
+            if device_name.split("-")[-1] in self.type_list:
+                dtype = device_name.split("-")[-1]
 
         if dtype:
-            device_name = device_name.split('-'+dtype)[0]
+            device_name = device_name.split("-" + dtype)[0]
 
         dev_raw = self.nbi.get_devices(name=device_name)
         if len(dev_raw) != 1:
-            raise Exception(f"Either {device_name} is not found or has multiple netbox entry")
-        
+            raise Exception(
+                f"Either {device_name} is not found or has multiple netbox entry"
+            )
+
         self.data.update({"devices": dev_raw[0]})
 
         # get associated console ports
-        cp_raw = self.nbi.get_console_ports(
-                device_id=self.data["devices"]["id"]
-            )
-        self.data['devices'].update({"console_ports":dict()})
+        cp_raw = self.nbi.get_console_ports(device_id=self.data["devices"]["id"])
+        self.data["devices"].update({"console_ports": dict()})
         for port in cp_raw:
-            self.data['devices']['console_ports'].update({port['name']: port})
+            self.data["devices"]["console_ports"].update({port["name"]: port})
 
         # get associated interfaces
-        inf_raw = self.nbi.get_interfaces(
-                device_id=self.data["devices"]["id"]
-            )
-        self.data['devices'].update({"interfaces":dict()})
+        inf_raw = self.nbi.get_interfaces(device_id=self.data["devices"]["id"])
+        self.data["devices"].update({"interfaces": dict()})
         for inf in inf_raw:
-            inf_name = inf['name']
-            if bool(inf['mgmt_only']):
+            inf_name = inf["name"]
+            if bool(inf["mgmt_only"]):
                 inf_name = "mgmt"
-            
+
             # add ip information
             ip_raw = self.nbi.get_ip_addresses(interface_id=inf["id"])
-            inf.update({"ip":ip_raw[0]})
-            self.data['devices']['interfaces'].update({inf_name: inf})
+            inf.update({"ip": ip_raw[0]})
+            self.data["devices"]["interfaces"].update({inf_name: inf})
 
         # get associated power ports
         pow_raw = self.nbi.get_power_ports(device_id=self.data["devices"]["id"])
-        self.data['devices'].update({"power_ports":dict()})
+        self.data["devices"].update({"power_ports": dict()})
         for pow in pow_raw:
-            #get associated oulet
-            outlet_id = pow['connected_endpoint']['id']
+            # get associated oulet
+            outlet_id = pow["connected_endpoint"]["id"]
             outlet = self.nbi.get_power_outlets(id=outlet_id)
-            pow['connected_endpoint']['outlet'] = outlet[0]['custom_fields']['outlet']
+            pow["connected_endpoint"]["outlet"] = outlet[0]["custom_fields"]["outlet"]
 
             # get ip of pdu
-            pdu_raw = self.nbi.get_devices(
-                id=pow['connected_endpoint']['device']['id']
-            )
-            pow['pdus'] = list()
+            pdu_raw = self.nbi.get_devices(id=pow["connected_endpoint"]["device"]["id"])
+            pow["pdus"] = list()
             for pdu in pdu_raw:
-                pow['pdus'].append(pdu)
+                pow["pdus"].append(pdu)
 
-            self.data['devices']['power_ports'].update({'input': pow})
+            self.data["devices"]["power_ports"].update({"input": pow})
 
         # update for type/variant
-        if 'variants' in self.data['devices']['config_context']:
-            variants_dict = self.data['devices']['config_context']['variants']
+        if "variants" in self.data["devices"]["config_context"]:
+            variants_dict = self.data["devices"]["config_context"]["variants"]
 
             if dtype:
                 if dtype in variants_dict:
                     log.info(f"Processing for type {dtype}")
                     variants_dict = variants_dict[dtype]
-                    device_name = device_name + '-' + dtype
+                    device_name = device_name + "-" + dtype
                 else:
                     raise Exception(f"Type {dtype} not defined")
 
@@ -217,77 +221,90 @@ class NetboxDevice():
                 if variant in variants_dict:
                     log.info(f"Processing for variant {variant}")
                     if variants_dict[variant] == "default":
-                        self.data['devices']['variant_data'] = None
+                        self.data["devices"]["variant_data"] = None
                     else:
-                        self.data['devices']['variant_data'] = json.dumps(variants_dict[variant])
-                    device_name = device_name + '-v' + variant
+                        self.data["devices"]["variant_data"] = json.dumps(
+                            variants_dict[variant]
+                        )
+                    device_name = device_name + "-v" + variant
                 else:
                     raise Exception(f"Variant {variant} not defined")
 
-            self.data['devices']['name'] = device_name
+            self.data["devices"]["name"] = device_name
 
         data_object = obj_dic(self.data)
         self.__dict__.update(data_object.__dict__.copy())
 
-    def to_config(self, template):
+    def to_config(self, template):  # noqa: C901
         log.info("Generating config for {}".format(self.devices.name))
-        template_dict= dict()
+        template_dict = dict()
         required_fields = list()
         if template:
-            for name,section in template.items():
+            for name, section in template.items():
                 template_dict[name] = dict()
                 for field in section.values():
                     try:
                         value = None
-                        if 'netbox_field' in field:
-                            value = eval('self.'+field['netbox_field'])
+                        if "netbox_field" in field:
+                            value = eval("self." + field["netbox_field"])
 
                             # check for Null/None values
                             if str(value) == "None":
                                 raise Exception(
-                                    "None value not valid for {}".\
-                                        format(field['name'])
+                                    "None value not valid for {}".format(field["name"])
                                 )
 
                             # check if value is a valid option
-                            if 'options' in field and str(value) not in field['options']:
-                                if 'optional' in field and bool(field['optional']) == False:
-                                    raise Exception("value {} not in valid options {}".\
-                                        format(value, field['options']))
+                            if (
+                                "options" in field
+                                and str(value) not in field["options"]
+                            ):
+                                if (
+                                    "optional" in field
+                                    and bool(field["optional"]) is False
+                                ):
+                                    raise Exception(
+                                        "value {} not in valid options {}".format(
+                                            value, field["options"]
+                                        )
+                                    )
 
                             # convert value to list if csv
-                            if isinstance(value, str) and len(value.split(',')) > 1:
-                                value = value.split(',')
+                            if isinstance(value, str) and len(value.split(",")) > 1:
+                                value = value.split(",")
 
                             # extract ip from cidr
-                            if isinstance(value, str) and len(value.split('/')) == 2:
-                                value = value.split('/')[0]
+                            if isinstance(value, str) and len(value.split("/")) == 2:
+                                value = value.split("/")[0]
                         else:
-                            raise Exception("netbox_field undefined for {}:{}".\
-                                format(name, field['name']))
+                            raise Exception(
+                                "netbox_field undefined for {}:{}".format(
+                                    name, field["name"]
+                                )
+                            )
 
-                        template_dict[name][field['name']] = value
+                        template_dict[name][field["name"]] = value
 
                     except Exception as ex:
-                        if 'optional' in field and bool(field['optional']) == True:
-                            log.warning(str(ex)+'.'+' Skipping since optional')
+                        if "optional" in field and bool(field["optional"]) is True:
+                            log.warning(str(ex) + "." + " Skipping since optional")
                             continue
 
-                        if 'default' in field:
-                            template_dict[name][field['name']] = field['default']
-                            log.warning(str(ex)+'.'+' Will try to use default')
+                        if "default" in field:
+                            template_dict[name][field["name"]] = field["default"]
+                            log.warning(str(ex) + "." + " Will try to use default")
                             continue
 
-                        log.error('Cannot parse {}'.format(field['name']))
+                        log.error("Cannot parse {}".format(field["name"]))
                         raise Exception("Template mapping failed")
                     finally:
                         # check if field had some required fields
-                        if 'requires' in field:
-                                answer = field['requires'].split(':')[0]
-                                if value == answer:
-                                    for rf in field['requires'].split(':')[1].split(','):
-                                        required_fields.append((name,rf))
-                
+                        if "requires" in field:
+                            answer = field["requires"].split(":")[0]
+                            if value == answer:
+                                for rf in field["requires"].split(":")[1].split(","):
+                                    required_fields.append((name, rf))
+
                 # remove empty sections
                 if not template_dict[name]:
                     del template_dict[name]
@@ -296,69 +313,65 @@ class NetboxDevice():
         for r_sec, r_field in required_fields:
             try:
                 value = template_dict[r_sec][r_field]
-                log.info('{}{} with value {} exists'.\
-                    format(r_sec,r_field,value))
-            except:
-                log.error("A required field {}{} cannot be found".\
-                    format(r_sec, r_field))
+                log.info("{}{} with value {} exists".format(r_sec, r_field, value))
+            except Exception:
+                log.error(
+                    "A required field {}{} cannot be found".format(r_sec, r_field)
+                )
                 raise Exception("Template mapping failed")
 
         # update for variant
-        if hasattr(self.devices,'variant_data'):
+        if hasattr(self.devices, "variant_data"):
             if self.devices.variant_data:
                 for sctn_name, fld in json.loads(self.devices.variant_data).items():
                     for fld_name, fld_val in fld.items():
-                        if not sctn_name in template_dict:
+                        if sctn_name not in template_dict:
                             template_dict[sctn_name] = dict()
                         template_dict[sctn_name][fld_name] = fld_val
 
         # convert to fields to list
         template_dict_list = dict()
         for sctn, flds in template_dict.items():
-            template_dict_list[sctn] = \
-            [ {fld:fld_val} for fld, fld_val in flds.items() ]
+            template_dict_list[sctn] = [{fld: fld_val} for fld, fld_val in flds.items()]
 
         return template_dict_list
 
-class NetboxDevices():
-    ''' List of NetboxDevice '''
-    def __init__(self, ni, status="active", role='fpga_dut', agent=None):
+
+class NetboxDevices:
+    """List of NetboxDevice"""
+
+    def __init__(self, ni, status="active", role="fpga_dut", agent=None):
         # get cluster agent
         dut_bank_id = None
         for cluster in ni.get_clusters():
-            if 'custom_fields' in cluster \
-                and 'cluster_agent' in cluster['custom_fields']:
-                if cluster['custom_fields']['cluster_agent'] == agent:
-                    dut_bank_id = cluster['id']
+            if (
+                "custom_fields" in cluster
+                and "cluster_agent" in cluster["custom_fields"]
+            ):
+                if cluster["custom_fields"]["cluster_agent"] == agent:
+                    dut_bank_id = cluster["id"]
                     break
             else:
                 log.warning("cluster agent not defined")
- 
+
         if agent and not dut_bank_id:
             raise Exception(f"Cannot find agent {agent}")
 
-        #get devices
+        # get devices
         kwargs = dict()
         if dut_bank_id:
-            kwargs['cluster_id'] = dut_bank_id
-        
-        kwargs['role_name'] = role
-        kwargs['status'] = status
-        
-        devices_names = ni.get_devices_name(
-                    include_variants=True, 
-                    **kwargs
-                )
+            kwargs["cluster_id"] = dut_bank_id
 
-        self.devices = [ NetboxDevice(ni, dev) for dev in devices_names ]
+        kwargs["role_name"] = role
+        kwargs["status"] = status
 
+        devices_names = ni.get_devices_name(include_variants=True, **kwargs)
+
+        self.devices = [NetboxDevice(ni, dev) for dev in devices_names]
 
     def generate_config(self, template=None):
         template_dict = dict()
-        path = pathlib.Path(__file__).parent.absolute()
-
         for dev in self.devices:
             template_dict.update({dev.devices.name: dev.to_config(template)})
 
         return template_dict
-

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -7,6 +7,7 @@ import yaml
 import json
 import os
 import pathlib
+from pprint import pprint
 
 log = logging.getLogger(__name__)
 
@@ -312,7 +313,13 @@ class NetboxDevice():
                             template_dict[sctn_name] = dict()
                         template_dict[sctn_name][fld_name] = fld_val
 
-        return template_dict
+        # convert to fields to list
+        template_dict_list = dict()
+        for sctn, flds in template_dict.items():
+            template_dict_list[sctn] = \
+            [ {fld:fld_val} for fld, fld_val in flds.items() ]
+
+        return template_dict_list
 
 class NetboxDevices():
     ''' List of NetboxDevice '''

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -74,17 +74,20 @@ class netbox(utils):
         board_name=None,
         load_config=True
     ):
-        port = ":" + str(port) if port else ""
-        base_url = "/" + str(base_url) if base_url else ""
         self.netbox_server = ip
         self.netbox_server_port = port
         self.netbox_api_token = token
         self.netbox_base_url = base_url
-        self.nb = pynetbox.api(f"http://{ip}{port}{base_url}", token=token)
         if load_config:
             self.update_defaults_from_yaml(
                 yamlfilename, __class__.__name__, board_name=board_name
             )
+        
+        fport = ":" + str(self.netbox_server_port) if self.netbox_server_port else ""
+        fbase_url = "/" + str(self.netbox_base_url) if self.netbox_base_url else ""
+
+        self.nb = pynetbox.api(f"http://{self.netbox_server}{fport}{fbase_url}",
+            token=self.netbox_api_token)
 
     def interface(self):
         return self.nb

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -387,7 +387,8 @@ class NetboxDevices:
 
         kwargs["role_name"] = role
         kwargs["status"] = status
-        kwargs["tag"] = tag
+        if tag:
+            kwargs["tag"] = tag
 
         devices_names = ni.get_devices_name(include_variants=True, **kwargs)
 

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -72,7 +72,7 @@ class netbox(utils):
         base_url="",
         yamlfilename=None,
         board_name=None,
-        load_config=True
+        load_config=True,
     ):
         self.netbox_server = ip
         self.netbox_server_port = port
@@ -82,12 +82,14 @@ class netbox(utils):
             self.update_defaults_from_yaml(
                 yamlfilename, __class__.__name__, board_name=board_name
             )
-        
+
         fport = ":" + str(self.netbox_server_port) if self.netbox_server_port else ""
         fbase_url = "/" + str(self.netbox_base_url) if self.netbox_base_url else ""
 
-        self.nb = pynetbox.api(f"http://{self.netbox_server}{fport}{fbase_url}",
-            token=self.netbox_api_token)
+        self.nb = pynetbox.api(
+            f"http://{self.netbox_server}{fport}{fbase_url}",
+            token=self.netbox_api_token,
+        )
 
     def interface(self):
         return self.nb

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -7,7 +7,6 @@ import yaml
 import json
 import os
 import pathlib
-from pprint import pprint
 
 log = logging.getLogger(__name__)
 
@@ -354,17 +353,12 @@ class NetboxDevices():
         self.devices = [ NetboxDevice(ni, dev) for dev in devices_names ]
 
 
-    def generate_config(self, template_file=None):
+    def generate_config(self, template=None):
         template_dict = dict()
         path = pathlib.Path(__file__).parent.absolute()
 
-        if not template_file:
-            template_file = os.path.join(path, "resources", "template_gen.yaml")
-
-        with open(template_file, 'r') as f:
-            template = yaml.safe_load(f)
-            for dev in self.devices:
-                template_dict.update({dev.devices.name: dev.to_config(template)})
+        for dev in self.devices:
+            template_dict.update({dev.devices.name: dev.to_config(template)})
 
         return template_dict
 

--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -8,6 +8,7 @@
 #     options: <list of options> (Optional)
 #     optional: <False,True,depends> (depends is used when its a dependent property)
 #     requires: <answer needed>:<field name of fields depending on this one,second field name> (Optional)
+#     netbox_field: <equivalent netbox object attribute>
 
 board-config:
   field_1:
@@ -15,80 +16,94 @@ board-config:
     default: zynq-zc702-adv7511-ad9361-fmcomms2-3
     help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
+    netbox_field: devices.name
   field_2:
     name: carrier
     default: ZC702
     help: "Carrier board name"
     optional: False
+    netbox_field: devices.custom_fields.device_carrier
   field_3:
     name: daughter
     default: FMCOMMS2-3
     help: "Daugther board name"
     optional: False
+    netbox_field: devices.custom_fields.device_daughter
   field_4:
     name: monitoring-interface
     default: uart
     help: "Select monitoring interface"
     options: [uart, netconsole]
     optional: False
+    netbox_field: devices.custom_fields.monitoring_interface
   field_5:
     name: allow-jtag
     default: False
     help: "Allow use of JTAG"
     options: ["True", "False"]
     optional: False
+    netbox_field: devices.custom_fields.allow_jtag
 network-config:
   field_1:
     name: dutip
     default: 192.168.10.2
     help: "IP address of development board"
     optional: False
+    netbox_field: devices.interfaces.mgmt.ip.address
   field_2:
     name: dhcp
     help: "DHCP network to development board (False assumes static)"
     optional: False
     options: ["True", "False"]
     requires: False:nic,nicip
+    netbox_field: devices.interfaces.mgmt.custom_fields.dhcp
   field_3:
     name: nic
     default: eth0
     help: "NIC used to talk to development board"
     optional: depends
     callback: get_nics
+    netbox_field: devices.interfaces.mgmt.label
   field_4:
     name: nicip
     default: 192.168.10.1
     help: "NIC connected to development board ip address"
     optional: depends
+    netbox_field: devices.interfaces.mgmt.custom_fields.nicip
 pdu-config:
   field_1:
     name: pdu_type
     default: cyberpower
     help: "PDU type"
     options: [cyberpower, vesync]
-    optional: False
+    optional: True
     requires: vesync:username,password
+    netbox_field: devices.power_ports.input.pdus[0].device_type.manufacturer.slug
   field_2:
     name: pduip
     default: 192.168.30.2
     help: "IP address of PDU"
-    optional: False
+    optional: True
+    netbox_field: devices.power_ports.input.pdus[0].primary_ip.address
   field_3:
     name: outlet
     default: 1
     help: "Outlet number on PDU for dev board"
-    optional: False
+    optional: True
     type: int
+    netbox_field: devices.power_ports.input.connected_endpoint.outlet
   field_4:
     name: username
     default: "username"
     help: "Username needed for login (only need for vesync so far)"
     optional: depends
+    netbox_field: devices.power_ports.input.pdus[0].custom_fields.username
   field_5:
     name: password
     default: "password"
     help: "Password needed for login (only need for vesync so far)"
     optional: depends
+    netbox_field: devices.power_ports.input.pdus[0].custom_fields.password
 uart-config:
   field_1:
     name: address
@@ -96,82 +111,123 @@ uart-config:
     help: "UART Address"
     optional: False
     callback: get_uarts
+    netbox_field: devices.console_ports.UART.label
   field_2:
     name: baudrate
     default: 115200
     help: "UART baudrate"
     optional: False
+    netbox_field: devices.console_ports.UART.custom_fields.baudrate
   field_3:
     name: logfilename
     default: my.log
     help: "Output UART logfilename"
     optional: False
+    netbox_field: devices.custom_fields.logfilename
   field_4:
     name: uboot_done_string
     default: zynq-uboot>
     help: "Uboot menu prompt"
     optional: True
+    netbox_field: devices.custom_fields.uboot_done_string
 system-config:
   field_1:
     name: tftpserverip
     default: 192.168.30.1
     help: "TFTP server address"
-    optional: False
+    optional: True
+    netbox_field: devices.config_context.tftpserverip
   field_2:
     name: tftpserverroot
     default: /var/lib/tftpboot
     help: "TFTP folder location"
-    optional: False
+    optional: True
+    netbox_field: devices.config_context.tftpserverroot
 driver-config:
   field_1:
     name: iio_device_names
     default: ["axi-ad9144-hpc", "axi-ad9680-hpc"]
     help: "List of IIO devices on board"
     optional: False
+    netbox_field: devices.custom_fields.iio_device_names
 downloader-config:
   field_1:
     name: http_server_ip
     default: 192.168.2.1
     help: "IP address of build server with boot files"
     optional: True
+    netbox_field: devices.custom_fields.http_server_ip
   field_2:
     name: reference_boot_folder
     default: zynq-zc702-adv7511-ad9361-fmcomms2-3-4
     help: "Folder name where reference boot files exist for specific board. \nThis is the same as the boot folder name of the AD-FMC-SDCARD."
     optional: False
+    netbox_field: devices.custom_fields.reference_boot_folder
   field_3:
     name: devicetree_subfolder
     default: zynq-zc702-adv7511-ad9361-fmcomms2-3
     help: "Subfolder name under reference boot folder\nwhere devicetree files exists for specific boards."
-    optional: False
+    optional: True
+    netbox_field: devices.custom_fields.devicetree_subfolder
   field_4:
     name: boot_subfolder
     default: null
     help: "Subfolder name under reference boot folder\nwhere boot files exist for specific boards."
-    optional: False
+    optional: True
+    netbox_field: devices.custom_fields.boot_subfolder
   field_5:
     name: hdl_folder
     default: fmcomms2_zc702
     help: "Folder name where hdl files exist for specific boards."
-    optional: False
+    optional: True
+    netbox_field: devices.custom_fields.hdl_folder
 jtag-config:
   field_1:
     name: vivado_version
     default: 2019.1
     help: "Version of vivado to use"
     optional: True
+    netbox_field: devices.config_context.vivado_version
   field_2:
     name: custom_vivado_path
     default: None
     help: "Custom path to vivado including version.\nEx: /opt/Xilinx/Vivado/2019.1\nOverrides vivado_version if set"
     optional: True
+    netbox_field: devices.config_context.custom_vivado_path
   field_3:
     name: jtag_cable_id
     default: 210299A567FE
     help: "Substring of JTAG cable ID. Run 'jtag target' through xsdb to get it.\n Just really need code not full name."
     optional: True
+    netbox_field: devices.console_ports.JTAG.label
   field_4:
     name: jtag_cpu_target_name
     default: ARM*#0
     help: "Name use to identify jtag target\n. This will be used for filtering jtag target.\n Can use wildcards e.x *"
     optional: True
+    netbox_field: devices.custom_fields.jtag_cpu_target_name
+netbox-config:
+  field_1:
+    name: netbox_server
+    help: "IP address of the netbox server"
+    default: 192.168.10.1
+    optional: True
+    netbox_field: devices.config_context.netbox_server
+  field_2:
+    name: netbox_server_port
+    default: 8000
+    help: "Port used by the netbox service"
+    optional: True
+    netbox_field: devices.config_context.netbox_port
+  field_3:
+    name: netbox_base_url
+    default: netbox
+    help: "String used as netbox base url. i.e server:port\base_url"
+    optional: True
+    netbox_field: devices.config_context.netbox_base_url
+  field_4:
+    name: netbox_api_token
+    default: 0123456789abcdef0123456789abcdef01234567
+    help: "Token for netbox rest api access"
+    optional: True
+    netbox_field: devices.config_context.netbox_api_token

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -327,7 +327,7 @@ def gen_config_netbox(
     board_name=None,
     devices_status=None,
     devices_role=None,
-    devices_tag=None
+    devices_tag=None,
 ):
     """Generate YAML configuration from netbox"""
     h = nebula.helper()
@@ -341,7 +341,7 @@ def gen_config_netbox(
         board_name=board_name,
         devices_status=devices_status,
         devices_role=devices_role,
-        devices_tag=devices_tag
+        devices_tag=devices_tag,
     )
 
 

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -314,6 +314,9 @@ def update_config(
         "netbox_baseurl": "baseurl pointing to netbox instance (if exist)",
         "jenkins_agent": "Target Jenkins agent to generate config to",
         "board_name": "Target board to generate config to, takes higher priority over jenkins_agent",
+        "devices_status": "Select only devices with the specified device status defined in netbox",
+        "devices_role": "Select only devices with the specified device role defined in netbox",
+        "devices_tag": "Select only devices with the specified device tag defined in netbox",
     },
 )
 def gen_config_netbox(

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -304,6 +304,36 @@ def update_config(
         board_name=board_name,
     )
 
+@task(
+    help={
+        "netbox_ip": "IP of netbox server",
+        "netbox_port": "Port netbox is running on the netbox server",
+        "netbox_token": "Token for authenticating API requests",
+        "netbox_baseurl": "baseurl pointing to netbox instance (if exist)",
+        "jenkins_agent": "Target Jenkins agent to generate config to",
+        "board_name": "Target board to generate config to, takes higher priority over jenkins_agent"
+    },
+)
+def gen_config_netbox(
+    c,
+    netbox_ip="localhost",
+    netbox_token="0123456789abcdef0123456789abcdef01234567",
+    netbox_port=None,
+    netbox_baseurl=None,
+    jenkins_agent=None,
+    board_name=None
+):
+    """Generate YAML configuration from netbox"""
+    h = nebula.helper()
+    h.create_config_from_netbox(
+        netbox_ip=netbox_ip,
+        netbox_port=netbox_port,
+        netbox_baseurl=netbox_baseurl,
+        netbox_token=netbox_token, 
+        jenkins_agent=jenkins_agent,
+        board_name=board_name
+    )
+
 
 #############################################
 @task(
@@ -849,6 +879,7 @@ ns = Collection()
 ns.add_task(gen_config)
 ns.add_task(show_log)
 ns.add_task(update_config)
+ns.add_task(gen_config_netbox)
 
 ns.add_collection(builder)
 ns.add_collection(uart)

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -306,6 +306,7 @@ def update_config(
 
 @task(
     help={
+        "outfile": "Output file name",
         "netbox_ip": "IP of netbox server",
         "netbox_port": "Port netbox is running on the netbox server",
         "netbox_token": "Token for authenticating API requests",
@@ -316,6 +317,7 @@ def update_config(
 )
 def gen_config_netbox(
     c,
+    outfile="nebula",
     netbox_ip="localhost",
     netbox_token="0123456789abcdef0123456789abcdef01234567",
     netbox_port=None,
@@ -326,6 +328,7 @@ def gen_config_netbox(
     """Generate YAML configuration from netbox"""
     h = nebula.helper()
     h.create_config_from_netbox(
+        outfile=outfile,
         netbox_ip=netbox_ip,
         netbox_port=netbox_port,
         netbox_baseurl=netbox_baseurl,

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -304,6 +304,7 @@ def update_config(
         board_name=board_name,
     )
 
+
 @task(
     help={
         "outfile": "Output file name",
@@ -312,7 +313,7 @@ def update_config(
         "netbox_token": "Token for authenticating API requests",
         "netbox_baseurl": "baseurl pointing to netbox instance (if exist)",
         "jenkins_agent": "Target Jenkins agent to generate config to",
-        "board_name": "Target board to generate config to, takes higher priority over jenkins_agent"
+        "board_name": "Target board to generate config to, takes higher priority over jenkins_agent",
     },
 )
 def gen_config_netbox(
@@ -323,7 +324,7 @@ def gen_config_netbox(
     netbox_port=None,
     netbox_baseurl=None,
     jenkins_agent=None,
-    board_name=None
+    board_name=None,
 ):
     """Generate YAML configuration from netbox"""
     h = nebula.helper()
@@ -332,9 +333,9 @@ def gen_config_netbox(
         netbox_ip=netbox_ip,
         netbox_port=netbox_port,
         netbox_baseurl=netbox_baseurl,
-        netbox_token=netbox_token, 
+        netbox_token=netbox_token,
         jenkins_agent=jenkins_agent,
-        board_name=board_name
+        board_name=board_name,
     )
 
 

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -325,6 +325,9 @@ def gen_config_netbox(
     netbox_baseurl=None,
     jenkins_agent=None,
     board_name=None,
+    devices_status=None,
+    devices_role=None,
+    devices_tag=None
 ):
     """Generate YAML configuration from netbox"""
     h = nebula.helper()
@@ -336,6 +339,9 @@ def gen_config_netbox(
         netbox_token=netbox_token,
         jenkins_agent=jenkins_agent,
         board_name=board_name,
+        devices_status=devices_status,
+        devices_role=devices_role,
+        devices_tag=devices_tag
     )
 
 


### PR DESCRIPTION
This implements:
1. Mapping of nebula-config fields to its equivalent netbox attributes using the template_gen.yaml file.
2. Create class for NetboxDevice and NetboxDevices which abstracts device models on netbox. Currently, access to netbox is read only but may expanded to write as well to unify transactions from nebula -> netbox and vice versa.
3. Add tasks to generate nebula-config from an initialized NetboxDevice or NetboxDevices objects using the template_gen.yaml file as template.