### PR TITLE
Add task to execute commands over ssh and allow customization of template for nebula-config generation 

### DIFF
--- a/nebula/helper.py
+++ b/nebula/helper.py
@@ -286,10 +286,13 @@ class helper:
         devices_status=None,
         devices_role=None,
         devices_tag=None,
+        template=None,
     ):
         # Read in template
         path = pathlib.Path(__file__).parent.absolute()
-        template = os.path.join(path, "resources", "template_gen.yaml")
+        template = os.path.join(
+            path, "resources", template if template else "template_gen.yaml"
+        )
         ni = netbox(
             ip=netbox_ip,
             port=netbox_port,

--- a/nebula/network.py
+++ b/nebula/network.py
@@ -133,8 +133,9 @@ class network(utils):
                 if t >= (retries - 1):
                     raise Exception("Exception occurred during SSH Reboot", str(ex))
 
-    def run_ssh_command(self, command, ignore_exceptions=False):
-        retries = 3
+    def run_ssh_command(
+        self, command, ignore_exceptions=False, retries=3, show_log=True
+    ):
         result = None
         for t in range(retries):
             log.info(
@@ -147,13 +148,24 @@ class network(utils):
                 ).run(command, hide=True, timeout=self.ssh_timeout)
                 if result.failed:
                     raise Exception("Failed to run command:", command)
+
+                if show_log and result.stdout:
+                    log.info("result stdout begin -------------------------------")
+                    log.info(f"{result.stdout}")
+                    log.info("result stdout end -------------------------------")
+
+                if show_log and result.stderr:
+                    log.info("result stderr begin -------------------------------")
+                    log.info(f"{result.stderr}")
+                    log.info("result stderr end -------------------------------")
+
                 break
             except Exception as ex:
                 log.warning("Exception raised: " + str(ex))
                 if not ignore_exceptions:
                     time.sleep(3)
                     if t >= (retries - 1):
-                        raise Exception("SSH Failed")
+                        raise Exception("SSH Failed: " + str(ex))
 
         return result
 

--- a/nebula/resources/template_agent_gen.yaml
+++ b/nebula/resources/template_agent_gen.yaml
@@ -1,0 +1,71 @@
+# This file is used to generate questions for configuration file generation
+# Here is the structure
+# <section>-config:
+#   field_X:
+#     name: <field name>
+#     default: <default option> (Optional)
+#     help: <question asked user>
+#     options: <list of options> (Optional)
+#     optional: <False,True,depends> (depends is used when its a dependent property)
+#     requires: <answer needed>:<field name of fields depending on this one,second field name> (Optional)
+#     netbox_field: <equivalent netbox object attribute>
+
+board-config:
+  field_1:
+    name: board-name
+    default: zynq-zc702-adv7511-ad9361-fmcomms2-3
+    help: "Board plus carrier name used by hdl project.\nThis is usually the same as the boot folder name of the AD-FMC-SDCARD."
+    optional: False
+    netbox_field: devices.name
+network-config:
+  field_1:
+    name: dutip
+    default: 192.168.10.2
+    help: "IP address of development board"
+    optional: False
+    netbox_field: devices.interfaces.mgmt.ip.address
+  field_2:
+    name: dhcp
+    help: "DHCP network to development board (False assumes static)"
+    optional: False
+    options: ["True", "False"]
+    requires: False:nic,nicip
+    netbox_field: devices.interfaces.mgmt.custom_fields.dhcp
+  field_3:
+    name: nic
+    default: eth0
+    help: "NIC used to talk to development board"
+    optional: depends
+    callback: get_nics
+    netbox_field: devices.interfaces.mgmt.label
+  field_4:
+    name: nicip
+    default: 192.168.10.1
+    help: "NIC connected to development board ip address"
+    optional: depends
+    netbox_field: devices.interfaces.mgmt.custom_fields.nicip
+netbox-config:
+  field_1:
+    name: netbox_server
+    help: "IP address of the netbox server"
+    default: 192.168.10.1
+    optional: True
+    netbox_field: devices.config_context.netbox_server
+  field_2:
+    name: netbox_server_port
+    default: 8000
+    help: "Port used by the netbox service"
+    optional: True
+    netbox_field: devices.config_context.netbox_port
+  field_3:
+    name: netbox_base_url
+    default: netbox
+    help: "String used as netbox base url. i.e server:port\base_url"
+    optional: True
+    netbox_field: devices.config_context.netbox_base_url
+  field_4:
+    name: netbox_api_token
+    default: 0123456789abcdef0123456789abcdef01234567
+    help: "Token for netbox rest api access"
+    optional: True
+    netbox_field: devices.config_context.netbox_api_token

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -909,7 +909,7 @@ def run_command(
     ignore_exception=False,
     retries=3,
 ):
-    """Run command to expand sd card via IP"""
+    """Run command on remote via ip"""
     n = nebula.network(
         dutip=ip, dutusername=user, dutpassword=password, board_name=board_name
     )

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -317,6 +317,7 @@ def update_config(
         "devices_status": "Select only devices with the specified device status defined in netbox",
         "devices_role": "Select only devices with the specified device role defined in netbox",
         "devices_tag": "Select only devices with the specified device tag defined in netbox",
+        "template": "Template for config generation",
     },
 )
 def gen_config_netbox(
@@ -331,6 +332,7 @@ def gen_config_netbox(
     devices_status=None,
     devices_role=None,
     devices_tag=None,
+    template=None,
 ):
     """Generate YAML configuration from netbox"""
     h = nebula.helper()
@@ -345,6 +347,7 @@ def gen_config_netbox(
         devices_status=devices_status,
         devices_role=devices_role,
         devices_tag=devices_tag,
+        template=template,
     )
 
 

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -885,11 +885,40 @@ def run_diagnostics(
     n.run_diagnostics()
 
 
+@task(
+    help={
+        "ip": "IP address of board. Default from yaml",
+        "user": "Board username. Default: root",
+        "password": "Password for board. Default: analog",
+        "board_name": "Name of DUT design (Ex: zynq-zc706-adv7511-fmcdaq2). Require for multi-device config files",
+        "command": "Shell command to run via ssh. Supports linux systems for now.",
+        "ignore_exception": "Ignore errors encountered on the remote side.",
+        "retries": "Number of execution attempts",
+    }
+)
+def run_command(
+    c,
+    ip=None,
+    user="root",
+    password="analog",
+    board_name=None,
+    command=None,
+    ignore_exception=False,
+    retries=3,
+):
+    """Run command to expand sd card via IP"""
+    n = nebula.network(
+        dutip=ip, dutusername=user, dutpassword=password, board_name=board_name
+    )
+    n.run_ssh_command(command, ignore_exception, retries)
+
+
 net = Collection("net")
 net.add_task(restart_board)
 net.add_task(update_boot_files)
 net.add_task(check_dmesg)
 net.add_task(run_diagnostics)
+net.add_task(run_command)
 
 
 #############################################

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
             "resources/board_table.yaml",
             "resources/err_rejects.txt",
             "resources/noOS_projects.yaml",
+            "resources/template_agent_gen.yaml",
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
Implements:

1. Add task to execute commands over ssh.
2. Allow use of custom nebula-config template for nebula-config generation.