### PR TITLE
Write hw MAC at uEnv

### DIFF
--- a/nebula/resources/template_gen.yaml
+++ b/nebula/resources/template_gen.yaml
@@ -53,6 +53,12 @@ board-config:
     help: "Serial number of external IIO instrument connected to the carrier"
     optional: True
     netbox_field: devices.custom_fields.instr_serial
+  field_8:
+    name: hw-mac
+    default: 00:0a:35:05:ca:00
+    help: "Hardware MAC address of DUT carrier"
+    optional: True
+    netbox_field: devices.custom_fields.hw_mac
 network-config:
   field_1:
     name: dutip

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -1129,6 +1129,34 @@ def set_static_ip(
 
 @task(
     help={
+        "mac": "MAC Address to write in /boot/uEnv.txt",
+        "address": "UART device address (/dev/ttyACMO). If a yaml config exist it will override,"
+        + " if no yaml file exists and no address provided auto is used",
+        "yamlfilename": "Path to yaml config file. Default: /etc/default/nebula",
+        "board_name": "Name of DUT design (Ex: zynq-zc706-adv7511-fmcdaq2). Require for multi-device config files",
+    },
+)
+def write_mac_uEnv(
+    c,
+    mac,
+    address="auto",
+    yamlfilename="/etc/default/nebula",
+    board_name=None,
+):
+    """Set Static IP address of board of DUT from UART connection"""
+    try:
+        u = nebula.uart(
+            address=address, yamlfilename=yamlfilename, board_name=board_name
+        )
+        u.print_to_console = False
+        u.write_mac_uEnv(mac)
+        del u
+    except Exception as ex:
+        print(ex)
+
+
+@task(
+    help={
         "system_top_bit_filename": "Path to system_top.bit.",
         "uimagepath": "Path to kernel image.",
         "devtreepath": "Path to devicetree.",
@@ -1167,6 +1195,7 @@ uart.add_task(restart_board_uart, name="restart_board")
 uart.add_task(get_ip)
 uart.add_task(set_dhcp)
 uart.add_task(set_static_ip)
+uart.add_task(write_mac_uEnv)
 uart.add_task(get_carriername)
 uart.add_task(get_mezzanine)
 uart.add_task(get_uart_log)

--- a/nebula/uart.py
+++ b/nebula/uart.py
@@ -392,6 +392,23 @@ class uart(utils):
             self._read_for_time(period=1)
             self.start_log(logappend=True)
 
+    def write_mac_uEnv(self, address):
+        restart = False
+        if self.listen_thread_run:
+            restart = True
+            self.stop_log()
+        # Check if we need to login to the console
+        if not self._check_for_login():
+            raise Exception("Console inaccessible due to login failure")
+        cmd = "sed -i 's/ethaddr=\\([0-9A-Fa-f]\\{2\\}[:-]\\)\\{5\\}[0-9A-Fa-f]\\{2\\}"
+        cmd += "//g' /boot/uEnv.txt; "
+        cmd += 'printf " ethaddr=' + address + '" >> /boot/uEnv.txt; '
+        cmd += "ex -s +'v/\\S/d' -cwq /boot/uEnv.txt"
+        self._write_data(cmd)
+        if restart:
+            self._read_for_time(period=1)
+            self.start_log(logappend=True)
+
     def request_ip_dhcp(self, nic="eth0"):
         restart = False
         if self.listen_thread_run:


### PR DESCRIPTION
This should address the ping issue for boards with the same hw mac address.  The following lines can be added to the existing hw health check pipeline before setting the static ip and reboot.

`def mac_addr = nebula('update-config board-config hw-mac --board-name='+board)`
`harness.nebula("uart.write-mac-uEnv --mac="+mac_addr+" --board-name=${board}")`

I already added the hw_mac field in Netbox. 
http://gateway.englab/jenkins/blue/organizations/jenkins/Misc%2Fset_mac_uEnv/detail/set_mac_uEnv/17/pipeline

