### PR TITLE
Add downloader support for the new Jenkins flow

### DIFF
--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -116,14 +116,15 @@ def get_gitsha(url, daily=False, linux=False, hdl=False):
                         "linux_git_sha": props["git_sha"][0],
                     }
                     yaml.dump(linux_props, f)
-        except:
+        except Exception:
             # TODO: fetch info.txt and get linux or hdl gitsha from there
             bootpartition = {
-                    "bootpartition_folder": re.findall(exp, url)[0],
-                    "linux_git_sha": "NA",
-                    "hdl_git_sha": "NA",
-                }
+                "bootpartition_folder": re.findall(exp, url)[0],
+                "linux_git_sha": "NA",
+                "hdl_git_sha": "NA",
+            }
             yaml.dump(bootpartition, f)
+
 
 def gen_url(ip, branch, folder, filename, addl, url_template):
     if branch == "master":
@@ -278,10 +279,12 @@ def download_matlab_generate_bootbin(
             download_artifact(path, download_folder)
     return paths, rd_names
 
+
 def sanitize_artifactory_url(url):
     url = re.sub(r"%2F", "/", url)
-    url = re.sub("/ui/repos/tree/Properties/","/artifactory/",url)
+    url = re.sub("/ui/repos/tree/Properties/", "/artifactory/", url)
     return url
+
 
 def get_info_txt(url):
     art_path = ArtifactoryPath(sanitize_artifactory_url(url))
@@ -294,22 +297,23 @@ def get_info_txt(url):
     if not info_txt_path:
         raise Exception("Missing info.txt")
 
-    build_info = {"built_projects":[]}
+    build_info = {"built_projects": []}
     with info_txt_path.open() as fd:
-        with open('info.txt', 'wb') as out:
+        with open("info.txt", "wb") as out:
             content = fd.read()
             out.write(content)
-            info_txt = content.decode('utf-8').split("\n")
+            info_txt = content.decode("utf-8").split("\n")
             for line in info_txt:
-                match = re.match('[\s-]*(.+):(.+)', line)
+                match = re.match(r"[\s-]*(.+):(.+)", line)
                 if match:
                     build_info.update({match.group(1).strip(): match.group(2).strip()})
                 else:
-                    match = re.match('\s+-\s([-\w]+)', line)
+                    match = re.match(r"\s+-\s([-\w]+)", line)
                     if match:
                         build_info["built_projects"].append(match.group(1))
 
     return build_info
+
 
 class downloader(utils):
     def __init__(self, http_server_ip=None, yamlfilename=None, board_name=None):
@@ -419,7 +423,12 @@ class downloader(utils):
             )
 
         new_flow = False
-        for pipeline in ["HDL_PRs","Linux_PRs", "HDL_latest_commit", "Linux_latest_commit"]:
+        for pipeline in [
+            "HDL_PRs",
+            "Linux_PRs",
+            "HDL_latest_commit",
+            "Linux_latest_commit",
+        ]:
             if bool(re.search(pipeline, url_template)):
                 new_flow = True
 
@@ -463,11 +472,11 @@ class downloader(utils):
     ):
         if source == "artifactory":
             if url_template:
-                url_template = sanitize_artifactory_url(url_template) + "/boot_partition/{}/{}"
-            else:
                 url_template = (
-                    "https://{}/artifactory/sdg-generic-development/boot_partition/{}/{}/{}"
+                    sanitize_artifactory_url(url_template) + "/boot_partition/{}/{}"
                 )
+            else:
+                url_template = "https://{}/artifactory/sdg-generic-development/boot_partition/{}/{}/{}"
 
         log.info("Getting standard boot files")
         # Get kernel
@@ -768,7 +777,7 @@ class downloader(utils):
         noos=False,
         microblaze=False,
         rpi=False,
-        url_template=None
+        url_template=None,
     ):
         if not kernel:
             kernel = False
@@ -861,7 +870,7 @@ class downloader(utils):
                         kernel,
                         kernel_root,
                         dt,
-                        url_template
+                        url_template,
                     )
                 elif folder == "hdl_linux":
                     self._get_files_hdl(
@@ -891,7 +900,7 @@ class downloader(utils):
         noos=None,
         microblaze=None,
         rpi=None,
-        url_template=None
+        url_template=None,
     ):
         """download_boot_files Download bootfiles for target design.
         This method can download or move files from different locations
@@ -968,7 +977,7 @@ class downloader(utils):
             noos,
             microblaze,
             rpi,
-            url_template
+            url_template,
         )
 
     def download_sdcard_release(self, release="2019_R1"):

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -95,27 +95,35 @@ def get_gitsha(url, daily=False, linux=False, hdl=False):
         path = ArtifactoryPath(str(url))
         props = path.properties
         exp = "20[1-2][0-9]_[0-3][0-9]_[0-3][0-9]-[0-2][0-9]_[0-6][0-9]_[0-6][0-9]"
-        if not daily:
+        try:
+            if not daily:
+                bootpartition = {
+                    "bootpartition_folder": re.findall(exp, url)[0],
+                    "linux_git_sha": props["linux_git_sha"][0],
+                    "hdl_git_sha": props["hdl_git_sha"][0],
+                }
+                yaml.dump(bootpartition, f)
+            else:
+                if hdl:
+                    hdl_props = {
+                        "hdl_folder": re.findall(exp, url)[0],
+                        "hdl_git_sha": props["git_sha"][0],
+                    }
+                    yaml.dump(hdl_props, f)
+                if linux:
+                    linux_props = {
+                        "linux_folder": re.findall(exp, url)[0],
+                        "linux_git_sha": props["git_sha"][0],
+                    }
+                    yaml.dump(linux_props, f)
+        except:
+            # TODO: fetch info.txt and get linux or hdl gitsha from there
             bootpartition = {
-                "bootpartition_folder": re.findall(exp, url)[0],
-                "linux_git_sha": props["linux_git_sha"][0],
-                "hdl_git_sha": props["hdl_git_sha"][0],
-            }
+                    "bootpartition_folder": re.findall(exp, url)[0],
+                    "linux_git_sha": "NA",
+                    "hdl_git_sha": "NA",
+                }
             yaml.dump(bootpartition, f)
-        else:
-            if hdl:
-                hdl_props = {
-                    "hdl_folder": re.findall(exp, url)[0],
-                    "hdl_git_sha": props["git_sha"][0],
-                }
-                yaml.dump(hdl_props, f)
-            if linux:
-                linux_props = {
-                    "linux_folder": re.findall(exp, url)[0],
-                    "linux_git_sha": props["git_sha"][0],
-                }
-                yaml.dump(linux_props, f)
-
 
 def gen_url(ip, branch, folder, filename, addl, url_template):
     if branch == "master":
@@ -270,6 +278,38 @@ def download_matlab_generate_bootbin(
             download_artifact(path, download_folder)
     return paths, rd_names
 
+def sanitize_artifactory_url(url):
+    url = re.sub(r"%2F", "/", url)
+    url = re.sub("/ui/repos/tree/Properties/","/artifactory/",url)
+    return url
+
+def get_info_txt(url):
+    art_path = ArtifactoryPath(sanitize_artifactory_url(url))
+    info_txt_path = None
+    for p in art_path:
+        if "info.txt" in str(p):
+            info_txt_path = p
+            break
+
+    if not info_txt_path:
+        raise Exception("Missing info.txt")
+
+    build_info = {"built_projects":[]}
+    with info_txt_path.open() as fd:
+        with open('info.txt', 'wb') as out:
+            content = fd.read()
+            out.write(content)
+            info_txt = content.decode('utf-8').split("\n")
+            for line in info_txt:
+                match = re.match('[\s-]*(.+):(.+)', line)
+                if match:
+                    build_info.update({match.group(1).strip(): match.group(2).strip()})
+                else:
+                    match = re.match('\s+-\s([-\w]+)', line)
+                    if match:
+                        build_info["built_projects"].append(match.group(1))
+
+    return build_info
 
 class downloader(utils):
     def __init__(self, http_server_ip=None, yamlfilename=None, board_name=None):
@@ -377,8 +417,17 @@ class downloader(utils):
             raise Exception(
                 "No server IP or domain name specified. Must be defined in yaml or provided as input"
             )
-        # get url template base
-        url = gen_url(ip, branch, folder, filename, addl, url_template)
+
+        new_flow = False
+        for pipeline in ["HDL_PRs","Linux_PRs", "HDL_latest_commit", "Linux_latest_commit"]:
+            if bool(re.search(pipeline, url_template)):
+                new_flow = True
+
+        if new_flow:
+            url = url_template.format(folder, filename)
+        else:
+            # get url template base
+            url = gen_url(ip, branch, folder, filename, addl, url_template)
         self.url = url
         filename = os.path.join(dest, filename)
         log.info("URL: " + url)
@@ -410,11 +459,15 @@ class downloader(utils):
         kernel,
         kernel_root,
         dt,
+        url_template=None,
     ):
         if source == "artifactory":
-            url_template = (
-                "https://{}/artifactory/sdg-generic-development/boot_partition/{}/{}/{}"
-            )
+            if url_template:
+                url_template = sanitize_artifactory_url(url_template) + "/boot_partition/{}/{}"
+            else:
+                url_template = (
+                    "https://{}/artifactory/sdg-generic-development/boot_partition/{}/{}/{}"
+                )
 
         log.info("Getting standard boot files")
         # Get kernel
@@ -715,6 +768,7 @@ class downloader(utils):
         noos=False,
         microblaze=False,
         rpi=False,
+        url_template=None
     ):
         if not kernel:
             kernel = False
@@ -807,6 +861,7 @@ class downloader(utils):
                         kernel,
                         kernel_root,
                         dt,
+                        url_template
                     )
                 elif folder == "hdl_linux":
                     self._get_files_hdl(
@@ -836,6 +891,7 @@ class downloader(utils):
         noos=None,
         microblaze=None,
         rpi=None,
+        url_template=None
     ):
         """download_boot_files Download bootfiles for target design.
         This method can download or move files from different locations
@@ -912,6 +968,7 @@ class downloader(utils):
             noos,
             microblaze,
             rpi,
+            url_template
         )
 
     def download_sdcard_release(self, release="2019_R1"):

--- a/nebula/downloader.py
+++ b/nebula/downloader.py
@@ -293,7 +293,7 @@ def sanitize_artifactory_url(url):
     url = re.sub(r"%2F", "/", url)
     url = re.sub("/ui/repos/tree/Properties/", "/artifactory/", url)
     # rebase url
-    url = re.sub("/boot_partition/.*$", "",url)
+    url = re.sub("/boot_partition/.*$", "", url)
     return url
 
 

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -405,13 +405,13 @@ def download_sdcard(c, release="2019_R1"):
         "source_root": "Location of source boot files. Dependent on source.\nFor artifactory sources this is the domain name",
         "branch": "Name of branches to get related files. Default: release",
         "yamlfilename": "Path to yaml config file. Default: /etc/default/nebula",
-        "filetype": '''Selects type of related files to be downloaded. Options:
+        "filetype": """Selects type of related files to be downloaded. Options:
                     boot_partition (boot_partition files),
                     hdl_linux (old: separate hdl and linux),
-                    noos (no-OS files), 
+                    noos (no-OS files),
                     microblaze (microblaze files),
-                    rpi (rpi files), firmware . 
-                    Default: boot''',
+                    rpi (rpi files), firmware .
+                    Default: boot""",
         "url_template": "Custom URL template for Artifactory sources",
     },
 )
@@ -423,7 +423,7 @@ def download_boot_files(
     yamlfilename="/etc/default/nebula",
     board_name=None,
     filetype="boot_partition",
-    url_template=None
+    url_template=None,
 ):
     """Download bootfiles for a specific development system"""
     d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name)
@@ -451,7 +451,7 @@ def download_boot_files(
         noos=file["noos"],
         microblaze=file["microblaze"],
         rpi=file["rpi"],
-        url_template=url_template
+        url_template=url_template,
     )
 
 
@@ -522,7 +522,8 @@ def download_generate_bootbin_map_file(
 @task(
     help={
         "url": "Artifactory url to path with info.txt",
-        "field": "Field to show. Will show all if None.",
+        "field": "Field to show. Will show all if None."
+        + " Available: built_projects, BRANCH,PR_ID,TIMESTAMP,DIRECTION,Triggered by, COMMIT SHA, COMMIT_DATE",
         "csv": "Print to console as csv",
     },
 )
@@ -534,24 +535,28 @@ def download_info_txt(
 ):
     """Download info.txt and print value to console"""
     from nebula.downloader import get_info_txt
+
     build_info = get_info_txt(url)
     to_show = build_info
     if field:
         if field in build_info.keys():
-            to_show = {field:build_info[field]}
+            to_show = {field: build_info[field]}
         else:
             print(f"'{field}' not a valid field")
             return
     if csv:
         if "built_projects" in to_show.keys():
             if len(to_show.keys()) == 1:
-                to_show['built_projects'] = ",".join(to_show['built_projects'])
+                to_show["built_projects"] = ",".join(to_show["built_projects"])
             else:
-                to_show['built_projects'] = "#".join(to_show['built_projects'])
-        print(",".join(to_show.keys()))
+                to_show["built_projects"] = "#".join(to_show["built_projects"])
+
+        if len(to_show.keys()) != 1:
+            print(",".join(to_show.keys()))
         print(",".join(to_show.values()))
     else:
         print(to_show)
+
 
 dl = Collection("dl")
 dl.add_task(download_sdcard, "sdcard")

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -542,8 +542,7 @@ def download_info_txt(
         if field in build_info.keys():
             to_show = {field: build_info[field]}
         else:
-            print(f"'{field}' not a valid field")
-            return
+            raise Exception(f"'{field}' not a valid field")
     if csv:
         if "built_projects" in to_show.keys():
             if len(to_show.keys()) == 1:

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -405,8 +405,14 @@ def download_sdcard(c, release="2019_R1"):
         "source_root": "Location of source boot files. Dependent on source.\nFor artifactory sources this is the domain name",
         "branch": "Name of branches to get related files. Default: release",
         "yamlfilename": "Path to yaml config file. Default: /etc/default/nebula",
-        "filetype": "Selects type of related files to be downloaded. Options: boot (boot_partition files), noos (no-OS files), microblaze (microblaze files), rpi (rpi files), firmware . Default: boot",
-        # "boot_partition": "If filetype is boot and boot_partition is True, boot files are downloaded from boot partition folder, else from hdl and linux folders. Default: True "
+        "filetype": '''Selects type of related files to be downloaded. Options:
+                    boot_partition (boot_partition files),
+                    hdl_linux (old: separate hdl and linux),
+                    noos (no-OS files), 
+                    microblaze (microblaze files),
+                    rpi (rpi files), firmware . 
+                    Default: boot''',
+        "url_template": "Custom URL template for Artifactory sources",
     },
 )
 def download_boot_files(
@@ -417,21 +423,21 @@ def download_boot_files(
     yamlfilename="/etc/default/nebula",
     board_name=None,
     filetype="boot_partition",
+    url_template=None
 ):
     """Download bootfiles for a specific development system"""
     d = nebula.downloader(yamlfilename=yamlfilename, board_name=board_name)
     try:
         file = {
             "firmware": None,
-            "boot_partition": True,
+            "boot_partition": None,
+            "hdl_linux": None,
+            "hdl_linux_ci": None,
             "noos": None,
             "microblaze": None,
             "rpi": None,
         }
-        if filetype == "hdl_linux":
-            file["boot_partition"] = False
-        else:
-            file[filetype] = True
+        file[filetype] = True
     except Exception:
         raise Exception("Filetype no supported.")
 
@@ -445,6 +451,7 @@ def download_boot_files(
         noos=file["noos"],
         microblaze=file["microblaze"],
         rpi=file["rpi"],
+        url_template=url_template
     )
 
 
@@ -512,11 +519,46 @@ def download_generate_bootbin_map_file(
     print("Mapping file saved to mapping.txt")
 
 
+@task(
+    help={
+        "url": "Artifactory url to path with info.txt",
+        "field": "Field to show. Will show all if None.",
+        "csv": "Print to console as csv",
+    },
+)
+def download_info_txt(
+    c,
+    url,
+    field=None,
+    csv=True,
+):
+    """Download info.txt and print value to console"""
+    from nebula.downloader import get_info_txt
+    build_info = get_info_txt(url)
+    to_show = build_info
+    if field:
+        if field in build_info.keys():
+            to_show = {field:build_info[field]}
+        else:
+            print(f"'{field}' not a valid field")
+            return
+    if csv:
+        if "built_projects" in to_show.keys():
+            if len(to_show.keys()) == 1:
+                to_show['built_projects'] = ",".join(to_show['built_projects'])
+            else:
+                to_show['built_projects'] = "#".join(to_show['built_projects'])
+        print(",".join(to_show.keys()))
+        print(",".join(to_show.values()))
+    else:
+        print(to_show)
+
 dl = Collection("dl")
 dl.add_task(download_sdcard, "sdcard")
 dl.add_task(download_boot_files, "bootfiles")
 dl.add_task(download_generate_matlab_bootbins, "matlab_bootbins")
 dl.add_task(download_generate_bootbin_map_file, "bootbin_map")
+dl.add_task(download_info_txt, "info_txt")
 
 
 #############################################

--- a/tests/files/info.txt
+++ b/tests/files/info.txt
@@ -1,0 +1,15 @@
+Boot partition created with arguments:
+  - BRANCH: main
+  - PR_ID: 1251
+  - TIMESTAMP: 2024_02_27-08_40_22
+  - DIRECTION: hdl_to_linux
+
+Triggered by: hdl
+  - COMMIT SHA: 7539df769
+  - COMMIT_DATE: 2024-02-27-17-38-45-
+
+Built projects:
+  - zynq-coraz7s-cn0540
+  - zynq-zed-adv7511-ad4020
+  - zynq-zed-adv7511-ad7768-1-evb
+  - zynq-zed-adv7511-cn0363

--- a/tests/nebula_config/nebula.yaml
+++ b/tests/nebula_config/nebula.yaml
@@ -43,6 +43,18 @@ zynq-zc706-adv7511-fmcomms11:
     - adf4355
     - axi-ad9625-hpc
     - axi-ad9162-hpc
+zynq-zed-adv7511-ad7768-1-evb:
+  board-config:
+  - board-name: zynq-zed-adv7511-ad7768-1-evb
+  - carrier: ZED
+  - daughter: AD7768-1-EVB
+  - monitoring-interface: uart
+  - allow-jtag: True
+  - serial: ''
+  - instr-serial: NA
+  downloader-config:
+  - reference_boot_folder: zynq-zed-adv7511-ad7768-1-evb
+  - hdl_folder: ad77681evb_zed
 eval-adxrs290-pmdz:
   board-config:
   - board-name: eval-adxrs290-pmdz

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,3 +182,31 @@ def test_usbmux_backup_update_modules(power_off_dut, config):
         + config[0]
     )
     assert o.return_code == 0
+
+
+@pytest.mark.hardware
+@pytest.mark.parametrize(
+    "field", [
+        "",
+        "built_projects",
+        "BRANCH",
+        "PR_ID",
+        "TIMESTAMP",
+        "DIRECTION",
+        "\"Triggered by\"",
+        "\"COMMIT SHA\"",
+        "COMMIT_DATE"
+    ]
+)
+def test_download_info_txt(field):
+    url = "https://artifactory.analog.com/ui/repos/tree/Properties/sdg-generic-development"+\
+         "%2Ftest_upload%2Fmain%2FHDL_PRs%2Fpr_1251%2F2024_02_27-08_40_22"
+    cmd = f"nebula dl.info-txt --url {url}"
+    if field:
+        cmd = cmd + f" --field {field}"
+
+    c = con("localhost")
+    o = c.local(cmd)
+    assert o.return_code == 0
+    assert os.path.exists("info.txt")
+    os.remove("info.txt")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,21 +186,24 @@ def test_usbmux_backup_update_modules(power_off_dut, config):
 
 @pytest.mark.hardware
 @pytest.mark.parametrize(
-    "field", [
+    "field",
+    [
         "",
         "built_projects",
         "BRANCH",
         "PR_ID",
         "TIMESTAMP",
         "DIRECTION",
-        "\"Triggered by\"",
-        "\"COMMIT SHA\"",
-        "COMMIT_DATE"
-    ]
+        '"Triggered by"',
+        '"COMMIT SHA"',
+        "COMMIT_DATE",
+    ],
 )
 def test_download_info_txt(field):
-    url = "https://artifactory.analog.com/ui/repos/tree/Properties/sdg-generic-development"+\
-         "%2Ftest_upload%2Fmain%2FHDL_PRs%2Fpr_1251%2F2024_02_27-08_40_22"
+    url = (
+        "https://artifactory.analog.com/ui/repos/tree/Properties/sdg-generic-development"
+        + "%2Ftest_upload%2Fmain%2FHDL_PRs%2Fpr_1251%2F2024_02_27-08_40_22"
+    )
     cmd = f"nebula dl.info-txt --url {url}"
     if field:
         cmd = cmd + f" --field {field}"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -128,5 +128,25 @@ def test_image_downloader():
     assert os.path.isfile("2019_R1-2020_02_04.img")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://artifactory.analog.com/ui/repos/tree/Properties/sdg-generic-development%2Ftest_upload%2Fmain%2FHDL_PRs%2Fpr_1251%2F2024_02_27-08_40_22"
+    ],
+)
+def test_get_info_txt(url):
+    from nebula.downloader import get_info_txt
+
+    build_info = get_info_txt(url)
+    assert os.path.isfile("info.txt")
+    assert "BRANCH" in build_info.keys()
+    assert "PR_ID" in build_info.keys()
+    assert "TIMESTAMP" in build_info.keys()
+    assert "DIRECTION" in build_info.keys()
+    assert "Triggered by" in build_info.keys()
+    assert "COMMIT SHA" in build_info.keys()
+    assert "COMMIT_DATE" in build_info.keys()
+
+
 if __name__ == "__main__":
     test_image_downloader()

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,16 +1,18 @@
 import os
+import pathlib
 import shutil
+from unittest.mock import Mock, patch
 
 import pytest
-import pathlib
-from unittest.mock import Mock, patch
 
 from nebula import downloader
 
 # Must be connected to analog VPN
 
 
-def downloader_test(board_name, branch, filetype, source="artifactory", url_template=None):
+def downloader_test(
+    board_name, branch, filetype, source="artifactory", url_template=None
+):
     file = {
         "firmware": None,
         "boot_partition": None,
@@ -22,7 +24,7 @@ def downloader_test(board_name, branch, filetype, source="artifactory", url_temp
         file["boot_partition"] = False
     else:
         file[filetype] = True
-    yaml = os.path.join(os.path.dirname(__file__),"nebula_config", "nebula.yaml")
+    yaml = os.path.join(os.path.dirname(__file__), "nebula_config", "nebula.yaml")
     d = downloader(yamlfilename=yaml, board_name=board_name)
     d.download_boot_files(
         board_name,
@@ -34,7 +36,7 @@ def downloader_test(board_name, branch, filetype, source="artifactory", url_temp
         noos=file["noos"],
         microblaze=file["microblaze"],
         rpi=file["rpi"],
-        url_template=url_template
+        url_template=url_template,
     )
 
 
@@ -122,14 +124,20 @@ def test_firmware_downloader(test_downloader, board_name, branch, filetype, sour
     else:
         assert len(os.listdir("outs")) == 1
 
+
 @pytest.mark.parametrize("board_name", ["zynq-zed-adv7511-ad7768-1-evb"])
 @pytest.mark.parametrize("branch", ["main"])
 @pytest.mark.parametrize("filetype", ["boot_partition"])
-@pytest.mark.parametrize("url_template", [
-                            "https://artifactory.analog.com/ui/repos/tree/Properties/sdg-generic-development"+\
-                            "%2Ftest_upload%2Fmain%2FHDL_PRs%2Fpr_1251%2F2024_02_27-08_40_22"
-                        ])
-def test_boot_downloader_new_flow(test_downloader, board_name, branch, filetype, url_template):
+@pytest.mark.parametrize(
+    "url_template",
+    [
+        "https://artifactory.analog.com/ui/repos/tree/Properties/sdg-generic-development"
+        + "%2Ftest_upload%2Fmain%2FHDL_PRs%2Fpr_1251%2F2024_02_27-08_40_22"
+    ],
+)
+def test_boot_downloader_new_flow(
+    test_downloader, board_name, branch, filetype, url_template
+):
     test_downloader(board_name, branch, filetype, url_template=url_template)
     assert os.path.isfile("outs/BOOT.BIN")
     assert os.path.isfile("outs/uImage")


### PR DESCRIPTION
This implements/updates the ff:
1. [add] download_info_txt (usage: nebula --help dl.info-txt) Download info.txt from a custom url_template and show all or selected fields in csv or dict format
2. [modify] download_boot_files (usage: nebula --help dl.bootfiles) Downloader support for boot_partition folders -  "HDL_PRs, Linux_PRs, HDL_latest_commit, Linux_latest_commit