### PR TITLE
tasks.py: Fix parameters default value

### DIFF
--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -753,8 +753,8 @@ def gen_config_netbox(
     board_name=None,
     include_variants=True,
     include_children=True,
-    devices_status=None,
-    devices_role=None,
+    devices_status="active",
+    devices_role="fpga-dut",
     devices_tag=None,
     template=None,
 ):


### PR DESCRIPTION
Parameters "status" and "role" should get the same default value as in netbox.py. These fields would otherwise get set to `None` and not to their intended values from the NetboxDevices constructor. This fixes the issue of sending an unsuported value when making a request to the netbox API.