### PR TITLE
netbox.py: Update script to support latest Netbox

### DIFF
--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -299,12 +299,12 @@ class NetboxDevice:
         self.data["devices"].update({"power_ports": dict()})
         for pow in pow_raw:
             # get associated oulet
-            outlet_id = pow["connected_endpoint"]["id"]
+            outlet_id = pow["connected_endpoints"][0]["id"]
             outlet = self.nbi.get_power_outlets(id=outlet_id)
-            pow["connected_endpoint"]["outlet"] = outlet[0]["custom_fields"]["outlet"]
+            pow["connected_endpoints"][0]["outlet"] = outlet[0]["custom_fields"]["outlet"]
 
             # get ip of pdu
-            pdu_raw = self.nbi.get_devices(id=pow["connected_endpoint"]["device"]["id"])
+            pdu_raw = self.nbi.get_devices(id=pow["connected_endpoints"][0]["device"]["id"])
             pow["pdus"] = list()
             for pdu in pdu_raw:
                 pow["pdus"].append(pdu)


### PR DESCRIPTION
Starting with v3.3, several Netbox API fields have been modified, including ones for power outlets (change introduced in netbox-community/netbox#9615). Update script to reflect those changes.

Tested on Netbox v4.1.2

❗ These changes should only be introduced after Netbox has been upgraded to latest (or any version >3.3)