### PR TITLE
Fix jtagcable id check

### DIFF
--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -51,6 +51,7 @@ class manager:
             self.power = pdu(yamlfilename=configfilename, board_name=board_name)
             log.info("PDU initialized")
 
+        # initialize JTAG
         self.jtag_use = False
         self.jtag = False
         if "board-config" in configs:
@@ -71,11 +72,16 @@ class manager:
                             )
                             self.power.power_cycle_board()
                             time.sleep(60)
-                            self.jtag = jtag(
-                                yamlfilename=configfilename,
-                                board_name=board_name,
-                                vivado_version=vivado_version,
-                            )
+                            try:
+                                self.jtag = jtag(
+                                    yamlfilename=configfilename,
+                                    board_name=board_name,
+                                    vivado_version=vivado_version,
+                                )
+                            except Exception as e2:
+                                log.info(str(e2))
+                                log.info("JTAG initialization failed.")
+                                self.jtag_use = False
                         log.info("JTAG initialized")
 
         if "netconsole" in monitor_type.lower():

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -65,6 +65,7 @@ class manager:
                                 board_name=board_name,
                                 vivado_version=vivado_version,
                             )
+                            log.info("JTAG initialized")
                         except Exception as e:
                             log.info(str(e))
                             log.info(
@@ -78,11 +79,12 @@ class manager:
                                     board_name=board_name,
                                     vivado_version=vivado_version,
                                 )
+                                log.info("JTAG initialized")
                             except Exception as e2:
                                 log.info(str(e2))
                                 log.info("JTAG initialization failed.")
                                 self.jtag_use = False
-                        log.info("JTAG initialized")
+                        
 
         if "netconsole" in monitor_type.lower():
             monitor_uboot = netconsole(port=6666, logfilename="uboot.log")

--- a/nebula/manager.py
+++ b/nebula/manager.py
@@ -84,7 +84,6 @@ class manager:
                                 log.info(str(e2))
                                 log.info("JTAG initialization failed.")
                                 self.jtag_use = False
-                        
 
         if "netconsole" in monitor_type.lower():
             monitor_uboot = netconsole(port=6666, logfilename="uboot.log")

--- a/nebula/netbox.py
+++ b/nebula/netbox.py
@@ -579,7 +579,9 @@ class NetboxDevice:
         else:
             self.nbi.update_status(device_id=device_id, status="offline")
 
-        self.nbi.log_journal(device_id=device_id, author_id=author.id, kind=kind, comments=reason)
+        self.nbi.log_journal(
+            device_id=device_id, author_id=author.id, kind=kind, comments=reason
+        )
 
     def status(self):
         device_id = self.data["devices"]["id"]

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -875,8 +875,9 @@ def board_diagnostics_manager(
         board_name=board_name,
         vivado_version=vivado_version,
     )
-    if not m.jtag_use:
-        raise Exception("JTAG not initialized")
+    if board_name not in ["m2k", "pluto"]:
+        if not m.jtag_use:
+            raise Exception("JTAG not initialized")
 
 
 @task(

--- a/nebula/tasks.py
+++ b/nebula/tasks.py
@@ -870,11 +870,13 @@ def board_diagnostics_manager(
     board_name=None,
 ):
     """Diagnose board using nebula classes"""
-    nebula.manager(
+    m = nebula.manager(
         configfilename=yamlfilename,
         board_name=board_name,
         vivado_version=vivado_version,
     )
+    if not m.jtag_use:
+        raise Exception("JTAG not initialized")
 
 
 @task(


### PR DESCRIPTION
This allows updating of bootfiles to still push through even though jtag  is not available.